### PR TITLE
Implement a generic AsyncButton with support for throwing closures

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -141,8 +141,6 @@ only_rules:
   - implicitly_unwrapped_optional
   # Identifiers should use inclusive language that avoids discrimination against groups of people based on race, gender, or socioeconomic status
   - inclusive_language
-  # If defer is at the end of its parent scope, it will be executed right where it is anyway.
-  - inert_defer
   # Prefer using Set.isDisjoint(with:) over Set.intersection(_:).isEmpty.
   - is_disjoint
   # Discouraged explicit usage of the default separator.
@@ -329,8 +327,6 @@ only_rules:
   - unowned_variable_capture
   # Catch statements should not declare error variables without type casting.
   - untyped_error_in_catch
-  # Unused reference in a capture list should be removed.
-  - unused_capture_list
   # Unused parameter in a closure should be replaced with _.
   - unused_closure_parameter
   # Unused control flow label should be removed.

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,8 +10,6 @@
 only_rules:
   # All Images that provide context should have an accessibility label. Purely decorative images can be hidden from accessibility.
   - accessibility_label_for_image
-  # Attributes should be on their own lines in functions and types, but on the same line as variables and imports.
-  - attributes
   # Prefer using Array(seq) over seq.map { $0 } to convert a sequence into an Array.
   - array_init
   # Prefer the new block based KVO API with keypaths when using Swift 3.2 or later.

--- a/Sources/SpeziViews/Environment/DefaultErrorDescription.swift
+++ b/Sources/SpeziViews/Environment/DefaultErrorDescription.swift
@@ -14,7 +14,7 @@ import SwiftUI
 /// sensible default for a localized default error description in the case that a sub-view has to display
 /// an ``AnyLocalizedError`` for a generic error.
 public struct DefaultErrorDescription: EnvironmentKey {
-    public static var defaultValue: LocalizedStringResource?
+    public static let defaultValue: LocalizedStringResource? = nil
 }
 
 extension EnvironmentValues {

--- a/Sources/SpeziViews/Environment/DefaultErrorDescription.swift
+++ b/Sources/SpeziViews/Environment/DefaultErrorDescription.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+
 /// An `EnvironmentKey` that provides access to the default, localized error description.
 ///
 /// This might be helpful for views that rely on ``AnyLocalizedError``. Outer views can define a

--- a/Sources/SpeziViews/Environment/ProcessingDebounceDuration.swift
+++ b/Sources/SpeziViews/Environment/ProcessingDebounceDuration.swift
@@ -1,0 +1,29 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+/// An `EnvironmentKey` that provides a generalized configuration for debounce durations for any processing-related operations.
+///
+/// This might be helpful to provide extensive customization points without introducing clutter in the initializer of views.
+/// The ``AsyncButton`` is one example where this `EnvironmentKey` is used.
+public struct ProcessingDebounceDuration: EnvironmentKey {
+    public static let defaultValue: Duration = .milliseconds(150)
+}
+
+extension EnvironmentValues {
+    /// Refer to the documentation of ``ProcessingDebounceDuration``.
+    public var processingDebounceDuration: Duration {
+        get {
+            self[ProcessingDebounceDuration.self]
+        }
+        set {
+            self[ProcessingDebounceDuration.self] = newValue
+        }
+    }
+}

--- a/Sources/SpeziViews/Environment/ProcessingDebounceDuration.swift
+++ b/Sources/SpeziViews/Environment/ProcessingDebounceDuration.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+
 /// An `EnvironmentKey` that provides a generalized configuration for debounce durations for any processing-related operations.
 ///
 /// This might be helpful to provide extensive customization points without introducing clutter in the initializer of views.
@@ -15,6 +16,7 @@ import SwiftUI
 public struct ProcessingDebounceDuration: EnvironmentKey {
     public static let defaultValue: Duration = .milliseconds(150)
 }
+
 
 extension EnvironmentValues {
     /// Refer to the documentation of ``ProcessingDebounceDuration``.

--- a/Sources/SpeziViews/Model/ViewState.swift
+++ b/Sources/SpeziViews/Model/ViewState.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Stanford Spezi open-source project
 //
-// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //
 // SPDX-License-Identifier: MIT
 //
@@ -10,15 +10,30 @@ import Foundation
 
 
 /// The ``ViewState`` allows SwiftUI views to keep track of their state and possible communicate it to outside views, e.g., using `Binding`s.
-public enum ViewState: Equatable {
+public enum ViewState {
     /// The view is idle and displaying content.
     case idle
     /// The view is in a processing state, e.g. loading content.
     case processing
     /// The view is in an error state, e.g., loading the content failed.
     case error(LocalizedError)
-    
-    
+}
+
+// MARK: - ViewState Extensions
+
+extension ViewState: Equatable {
+    public static func == (lhs: ViewState, rhs: ViewState) -> Bool {
+        switch (lhs, rhs) {
+        case (.idle, .idle), (.processing, .processing), (.error, .error):
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+// MARK: - ViewState + Error
+extension ViewState {
     /// The localized error title of the view if it is in an error state. An empty string if it is in an non-error state.
     public var errorTitle: String {
         switch self {
@@ -37,7 +52,7 @@ public enum ViewState: Equatable {
             return String(localized: "VIEW_STATE_DEFAULT_ERROR_TITLE", bundle: .module)
         }
     }
-    
+
     /// The localized error description of the view if it is in an error state. An empty string if it is in an non-error state.
     public var errorDescription: String {
         switch self {
@@ -58,16 +73,6 @@ public enum ViewState: Equatable {
             return errorDescription
         default:
             return ""
-        }
-    }
-    
-    
-    public static func == (lhs: ViewState, rhs: ViewState) -> Bool {
-        switch (lhs, rhs) {
-        case (.idle, .idle), (.processing, .processing), (.error, .error):
-            return true
-        default:
-            return false
         }
     }
 }

--- a/Sources/SpeziViews/ViewModifier/ProcessingOverlay.swift
+++ b/Sources/SpeziViews/ViewModifier/ProcessingOverlay.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Stanford Spezi open-source project
 //
-// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //
 // SPDX-License-Identifier: MIT
 //

--- a/Sources/SpeziViews/ViewModifier/ProcessingOverlay.swift
+++ b/Sources/SpeziViews/ViewModifier/ProcessingOverlay.swift
@@ -8,9 +8,11 @@
 
 import SwiftUI
 
+
 private struct ProcessingOverlay<Overlay: View>: ViewModifier {
     fileprivate var isProcessing: Bool
     @ViewBuilder fileprivate var overlay: () -> Overlay
+
 
     func body(content: Content) -> some View {
         content
@@ -22,6 +24,7 @@ private struct ProcessingOverlay<Overlay: View>: ViewModifier {
             }
     }
 }
+
 
 extension View {
     /// Modifies the view to be replaced by an processing indicator based on the supplied condition.

--- a/Sources/SpeziViews/ViewModifier/ProcessingOverlay.swift
+++ b/Sources/SpeziViews/ViewModifier/ProcessingOverlay.swift
@@ -1,0 +1,51 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+private struct ProcessingOverlay<Overlay: View>: ViewModifier {
+    fileprivate var isProcessing: Bool
+    @ViewBuilder fileprivate var overlay: () -> Overlay
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(isProcessing ? 0.0 : 1.0)
+            .overlay {
+                if isProcessing {
+                    overlay()
+                }
+            }
+    }
+}
+
+extension View {
+    /// Modifies the view to be replaced by an processing indicator based on the supplied condition.
+    /// - Parameters:
+    ///   - state: The `ViewState` that is used to determine whether the view is replaced by the processing overlay.
+    ///         We consider the view to be processing if the state is ``ViewState/processing``.
+    ///   - overlay: A view which which the modified view is overlayed with when state is processing.
+    /// - Returns: A view that may render processing state.
+    public func processingOverlay<Overlay: View>(
+        isProcessing state: ViewState,
+        @ViewBuilder overlay: @escaping () -> Overlay = { ProgressView() }
+    ) -> some View {
+        processingOverlay(isProcessing: state == .processing, overlay: overlay)
+    }
+
+    /// Modifies the view to be replaced by an processing indicator based on the supplied condition.
+    /// - Parameters:
+    ///   - processing: A Boolean value that determines whether the view is replaced by the processing overlay.
+    ///   - overlay: A view which which the modified view is overlayed with when state is processing.
+    /// - Returns: A view that may render processing state.
+    public func processingOverlay<Overlay: View>(
+        isProcessing processing: Bool,
+        @ViewBuilder overlay: @escaping () -> Overlay = { ProgressView() }
+    ) -> some View {
+        modifier(ProcessingOverlay(isProcessing: processing, overlay: overlay))
+    }
+}

--- a/Sources/SpeziViews/Views/Button/AsyncButton.swift
+++ b/Sources/SpeziViews/Views/Button/AsyncButton.swift
@@ -1,0 +1,208 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+enum AsyncButtonState {
+    case idle
+    case disabled
+    case disabledAndProcessing
+}
+
+/// A SwiftUI `Button` that initiates an asynchronous (throwing) action.
+@MainActor
+public struct AsyncButton<Label: View>: View {
+    private let role: ButtonRole?
+    private let action: () async throws -> Void
+    private let label: () -> Label
+
+    @Environment(\.defaultErrorDescription)
+    var defaultErrorDescription
+    @Environment(\.processingDebounceDuration)
+    var processingDebounceDuration
+
+    @State private var actionTask: Task<Void, Never>?
+
+    @State private var buttonState: AsyncButtonState = .idle
+    @Binding private var viewState: ViewState
+
+    // this covers the case where the encapsulating view sets the viewState binding to processing.
+    // This should also make the button to rendered as processing!
+    private var externallyProcessing: Bool {
+        buttonState == .idle && viewState == .processing
+    }
+
+    public var body: some View {
+        Button(role: role, action: submitAction) {
+            label()
+                .processingOverlay(isProcessing: buttonState == .disabledAndProcessing || externallyProcessing)
+        }
+            .disabled(buttonState != .idle || externallyProcessing)
+            .onDisappear {
+                actionTask?.cancel()
+            }
+    }
+
+    /// Creates am async button that generates its label from a provided localized string.
+    /// - Parameters:
+    ///   - title: The localized string used to generate the Label.
+    ///   - role: An optional button role that is passed onto the underlying `Button`.
+    ///   - action: An asynchronous button action.
+    public init(
+        _ title: LocalizedStringResource,
+        role: ButtonRole? = nil,
+        action: @escaping () async -> Void
+    ) where Label == Text {
+        self.init(role: role, action: action) {
+            Text(title)
+        }
+    }
+
+    /// Creates an async button that displays a custom label.
+    /// - Parameters:
+    ///   - role: An optional button role that is passed onto the underlying `Button`.
+    ///   - action: An asynchronous button action.
+    ///   - label: The Button label.
+    public init(
+        role: ButtonRole? = nil,
+        action: @escaping () async -> Void,
+        @ViewBuilder label: @escaping () -> Label
+    ) {
+        self.role = role
+        self.action = action
+        self.label = label
+        self._viewState = .constant(.idle)
+    }
+
+    /// Creates an async throwing button that generates its label from a provided localized string.
+    /// - Parameters:
+    ///   - title: The localized string used to generate the Label.
+    ///   - role: An optional button role that is passed onto the underlying `Button`.
+    ///   - state: A ``ViewState`` binding that it used to propagate any error caught in the button action.
+    ///         It may also be used to externally control or observe the button's processing state.
+    ///   - action: An asynchronous button action.
+    public init( // swiftlint:disable:this function_default_parameter_at_end
+        _ title: LocalizedStringResource,
+        role: ButtonRole? = nil,
+        state: Binding<ViewState>,
+        action: @escaping () async throws -> Void
+    ) where Label == Text {
+        self.init(role: role, state: state, action: action) {
+            Text(title)
+        }
+    }
+
+    /// Creates an async button that displays a custom label.
+    /// - Parameters:
+    ///   - role: An optional button role that is passed onto the underlying `Button`.
+    ///   - state: A ``ViewState`` binding that it used to propagate any error caught in the button action.
+    ///         It may also be used to externally control or observe the button's processing state.
+    ///   - action: An asynchronous button action.
+    ///   - label: The Button label.
+    public init( // swiftlint:disable:this function_default_parameter_at_end
+        role: ButtonRole? = nil,
+        state: Binding<ViewState>,
+        action: @escaping () async throws -> Void,
+        @ViewBuilder label: @escaping () -> Label
+    ) {
+        self.role = role
+        self._viewState = state
+        self.action = action
+        self.label = label
+    }
+
+    private func submitAction() {
+        guard viewState != .processing else {
+            return
+        }
+
+        buttonState = .disabled
+
+        withAnimation(.easeOut(duration: 0.2)) {
+            viewState = .processing
+        }
+
+        actionTask = Task {
+            do {
+                let debounce = Task {
+                    try await debounceProcessingIndicator()
+                }
+
+                try await action()
+                debounce.cancel()
+
+                // the button action might set the state back to idle to prevent this animation
+                if viewState != .idle {
+                    withAnimation(.easeIn(duration: 0.2)) {
+                        viewState = .idle
+                    }
+                }
+            } catch {
+                viewState = .error(AnyLocalizedError(
+                    error: error,
+                    defaultErrorDescription: defaultErrorDescription
+                ))
+            }
+
+            buttonState = .idle
+            actionTask = nil
+        }
+    }
+
+    private func debounceProcessingIndicator() async throws {
+        try await Task.sleep(for: processingDebounceDuration)
+
+        // this is actually important to catch cases where the action runs a tiny bit faster than the debounce timer
+        guard !Task.isCancelled else {
+            return
+        }
+
+        withAnimation(.easeOut(duration: 0.2)) {
+            buttonState = .disabledAndProcessing
+        }
+    }
+}
+
+#if DEBUG
+struct AsyncThrowingButton_Previews: PreviewProvider {
+    struct PreviewButton: View {
+        var title: LocalizedStringResource = "Test Button"
+        var role: ButtonRole?
+        var duration: Duration = .seconds(1)
+        var action: () async throws -> Void = {}
+
+        @State var state: ViewState = .idle
+
+        var body: some View {
+            AsyncButton(title, role: role, state: $state) {
+                try await Task.sleep(for: duration)
+                try await action()
+            }
+                .viewStateAlert(state: $state)
+        }
+    }
+
+    static var previews: some View {
+        Group {
+            PreviewButton()
+            PreviewButton(title: "Test Button with short action", duration: .milliseconds(100))
+            /*AsyncThrowingButton(state: $state, action: { print("button pressed") }) {
+                Text("Test Button!")
+            }*/
+            PreviewButton(title: "Test Button with Error") {
+                throw CancellationError()
+            }
+
+            PreviewButton(title: "Processing only Button", state: .processing)
+
+            PreviewButton(title: "Destructive Button", role: .destructive)
+        }
+            .buttonStyle(.borderedProminent)
+    }
+}
+#endif

--- a/Sources/SpeziViews/Views/Button/AsyncButton.swift
+++ b/Sources/SpeziViews/Views/Button/AsyncButton.swift
@@ -8,11 +8,13 @@
 
 import SwiftUI
 
+
 enum AsyncButtonState {
     case idle
     case disabled
     case disabledAndProcessing
 }
+
 
 /// A SwiftUI `Button` that initiates an asynchronous (throwing) action.
 @MainActor
@@ -47,6 +49,7 @@ public struct AsyncButton<Label: View>: View {
                 actionTask?.cancel()
             }
     }
+
 
     /// Creates am async button that generates its label from a provided localized string.
     /// - Parameters:
@@ -116,6 +119,7 @@ public struct AsyncButton<Label: View>: View {
         self.label = label
     }
 
+
     private func submitAction() {
         guard viewState != .processing else {
             return
@@ -167,6 +171,7 @@ public struct AsyncButton<Label: View>: View {
         }
     }
 }
+
 
 #if DEBUG
 struct AsyncThrowingButton_Previews: PreviewProvider {

--- a/Tests/UITests/TestApp.xctestplan
+++ b/Tests/UITests/TestApp.xctestplan
@@ -9,6 +9,15 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : {
+      "targets" : [
+        {
+          "containerPath" : "container:..\/..",
+          "identifier" : "SpeziViews",
+          "name" : "SpeziViews"
+        }
+      ]
+    },
     "targetForVariableExpansion" : {
       "containerPath" : "container:UITests.xcodeproj",
       "identifier" : "2F6D139128F5F384007C25D6",

--- a/Tests/UITests/TestApp/SpeziViewsTests.swift
+++ b/Tests/UITests/TestApp/SpeziViewsTests.swift
@@ -26,15 +26,18 @@ enum SpeziViewsTests: String, TestAppTests {
     case asyncButton = "Async Button"
     
     
-    @ViewBuilder private var canvas: some View {
+    @ViewBuilder
+    private var canvas: some View {
         CanvasTestView()
     }
     
-    @ViewBuilder private var nameFields: some View {
+    @ViewBuilder
+    private var nameFields: some View {
         NameFieldsTestView()
     }
     
-    @ViewBuilder private var userProfile: some View {
+    @ViewBuilder
+    private var userProfile: some View {
         UserProfileView(
             name: PersonNameComponents(givenName: "Paul", familyName: "Schmiedmayer")
         )
@@ -49,11 +52,13 @@ enum SpeziViewsTests: String, TestAppTests {
             .frame(width: 200)
     }
     
-    @ViewBuilder private var geometryReader: some View {
+    @ViewBuilder
+    private var geometryReader: some View {
         GeometryReaderTestView()
     }
     
-    @ViewBuilder private var label: some View {
+    @ViewBuilder
+    private var label: some View {
         Label(
             """
             This is a label ...
@@ -74,15 +79,18 @@ enum SpeziViewsTests: String, TestAppTests {
             .border(.red)
     }
     
-    @ViewBuilder private var markdownView: some View {
+    @ViewBuilder
+    private var markdownView: some View {
         MarkdownViewTestView()
     }
 
-    @ViewBuilder private var htmlView: some View {
+    @ViewBuilder
+    private var htmlView: some View {
         HTMLViewTestView()
     }
     
-    @ViewBuilder private var lazyText: some View {
+    @ViewBuilder
+    private var lazyText: some View {
         ScrollView {
             LazyText(
                 text: """
@@ -96,19 +104,23 @@ enum SpeziViewsTests: String, TestAppTests {
         }
     }
     
-    @ViewBuilder private var viewState: some View {
+    @ViewBuilder
+    private var viewState: some View {
         ViewStateTestView()
     }
 
-    @ViewBuilder private var defaultErrorOnly: some View {
+    @ViewBuilder
+    private var defaultErrorOnly: some View {
         ViewStateTestView(testError: .init(errorDescription: "Some error occurred!"))
     }
 
-    @ViewBuilder private var defaultErrorDescription: some View {
+    @ViewBuilder
+    private var defaultErrorDescription: some View {
         DefaultErrorDescriptionTestView()
     }
 
-    @ViewBuilder private var asyncButton: some View {
+    @ViewBuilder
+    private var asyncButton: some View {
         AsyncButtonTestView()
     }
     

--- a/Tests/UITests/TestApp/SpeziViewsTests.swift
+++ b/Tests/UITests/TestApp/SpeziViewsTests.swift
@@ -42,7 +42,7 @@ enum SpeziViewsTests: String, TestAppTests {
         UserProfileView(
             name: PersonNameComponents(givenName: "Leland", familyName: "Stanford"),
             imageLoader: {
-                try? await Task.sleep(for: .seconds(1))
+                try? await Task.sleep(for: .seconds(3))
                 return Image(systemName: "person.crop.artframe")
             }
         )

--- a/Tests/UITests/TestApp/SpeziViewsTests.swift
+++ b/Tests/UITests/TestApp/SpeziViewsTests.swift
@@ -23,6 +23,7 @@ enum SpeziViewsTests: String, TestAppTests {
     case viewState = "View State"
     case defaultErrorOnly = "Default Error Only"
     case defaultErrorDescription = "Default Error Description"
+    case asyncButton = "Async Button"
     
     
     @ViewBuilder
@@ -117,6 +118,11 @@ enum SpeziViewsTests: String, TestAppTests {
     private var defaultErrorDescription: some View {
         DefaultErrorDescriptionTestView()
     }
+
+    @ViewBuilder
+    private var asyncButton: some View {
+        AsyncButtonTestView()
+    }
     
 
     // swiftlint:disable:next cyclomatic_complexity
@@ -144,6 +150,8 @@ enum SpeziViewsTests: String, TestAppTests {
             defaultErrorOnly
         case .defaultErrorDescription:
             defaultErrorDescription
+        case .asyncButton:
+            asyncButton
         }
     }
 }

--- a/Tests/UITests/TestApp/SpeziViewsTests.swift
+++ b/Tests/UITests/TestApp/SpeziViewsTests.swift
@@ -26,18 +26,15 @@ enum SpeziViewsTests: String, TestAppTests {
     case asyncButton = "Async Button"
     
     
-    @ViewBuilder
-    private var canvas: some View {
+    @ViewBuilder private var canvas: some View {
         CanvasTestView()
     }
     
-    @ViewBuilder
-    private var nameFields: some View {
+    @ViewBuilder private var nameFields: some View {
         NameFieldsTestView()
     }
     
-    @ViewBuilder
-    private var userProfile: some View {
+    @ViewBuilder private var userProfile: some View {
         UserProfileView(
             name: PersonNameComponents(givenName: "Paul", familyName: "Schmiedmayer")
         )
@@ -52,13 +49,11 @@ enum SpeziViewsTests: String, TestAppTests {
             .frame(width: 200)
     }
     
-    @ViewBuilder
-    private var geometryReader: some View {
+    @ViewBuilder private var geometryReader: some View {
         GeometryReaderTestView()
     }
     
-    @ViewBuilder
-    private var label: some View {
+    @ViewBuilder private var label: some View {
         Label(
             """
             This is a label ...
@@ -79,18 +74,15 @@ enum SpeziViewsTests: String, TestAppTests {
             .border(.red)
     }
     
-    @ViewBuilder
-    private var markdownView: some View {
+    @ViewBuilder private var markdownView: some View {
         MarkdownViewTestView()
     }
 
-    @ViewBuilder
-    private var htmlView: some View {
+    @ViewBuilder private var htmlView: some View {
         HTMLViewTestView()
     }
     
-    @ViewBuilder
-    private var lazyText: some View {
+    @ViewBuilder private var lazyText: some View {
         ScrollView {
             LazyText(
                 text: """
@@ -104,23 +96,19 @@ enum SpeziViewsTests: String, TestAppTests {
         }
     }
     
-    @ViewBuilder
-    private var viewState: some View {
+    @ViewBuilder private var viewState: some View {
         ViewStateTestView()
     }
 
-    @ViewBuilder
-    private var defaultErrorOnly: some View {
+    @ViewBuilder private var defaultErrorOnly: some View {
         ViewStateTestView(testError: .init(errorDescription: "Some error occurred!"))
     }
 
-    @ViewBuilder
-    private var defaultErrorDescription: some View {
+    @ViewBuilder private var defaultErrorDescription: some View {
         DefaultErrorDescriptionTestView()
     }
 
-    @ViewBuilder
-    private var asyncButton: some View {
+    @ViewBuilder private var asyncButton: some View {
         AsyncButtonTestView()
     }
     

--- a/Tests/UITests/TestApp/ViewsTests/AsyncButtonTestView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/AsyncButtonTestView.swift
@@ -1,0 +1,60 @@
+//
+//  AsyncButtonTestView.swift
+//  TestApp
+//
+//  Created by Andreas Bauer on 13.07.23.
+//
+
+import SpeziViews
+import SwiftUI
+
+enum CustomError: Error, LocalizedError {
+    case error
+
+    var errorDescription: String? {
+        "Custom Error"
+    }
+
+    var failureReason: String? {
+        "Error was thrown!"
+    }
+}
+
+struct AsyncButtonTestView: View {
+    @State private var showCompleted: Bool = false
+    @State private var viewState: ViewState = .idle
+
+    var body: some View {
+        List {
+            if showCompleted {
+                Section {
+                    Text("Action exectued")
+                    Button("Reset") {
+                        showCompleted = false
+                    }
+                }
+            }
+            Group {
+                AsyncButton("Hello World") {
+                    try? await Task.sleep(for: .milliseconds(500))
+                    showCompleted = true
+                }
+
+                AsyncButton("Hello Throwing World", role: .destructive, state: $viewState) {
+                    try? await Task.sleep(for: .milliseconds(500))
+                    throw CustomError.error
+                }
+            }
+                .disabled(showCompleted)
+                .viewStateAlert(state: $viewState)
+        }
+    }
+}
+
+#if DEBUG
+struct AsyncButtonTestView_Previews: PreviewProvider {
+    static var previews: some View {
+        AsyncButtonTestView()
+    }
+}
+#endif

--- a/Tests/UITests/TestApp/ViewsTests/AsyncButtonTestView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/AsyncButtonTestView.swift
@@ -1,8 +1,9 @@
 //
-//  AsyncButtonTestView.swift
-//  TestApp
+// This source file is part of the Stanford Spezi open-source project
 //
-//  Created by Andreas Bauer on 13.07.23.
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
 //
 
 import SpeziViews
@@ -21,14 +22,14 @@ enum CustomError: Error, LocalizedError {
 }
 
 struct AsyncButtonTestView: View {
-    @State private var showCompleted: Bool = false
+    @State private var showCompleted = false
     @State private var viewState: ViewState = .idle
 
     var body: some View {
         List {
             if showCompleted {
                 Section {
-                    Text("Action exectued")
+                    Text("Action executed")
                     Button("Reset") {
                         showCompleted = false
                     }

--- a/Tests/UITests/TestApp/ViewsTests/AsyncButtonTestView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/AsyncButtonTestView.swift
@@ -9,6 +9,7 @@
 import SpeziViews
 import SwiftUI
 
+
 enum CustomError: Error, LocalizedError {
     case error
 
@@ -20,6 +21,7 @@ enum CustomError: Error, LocalizedError {
         "Error was thrown!"
     }
 }
+
 
 struct AsyncButtonTestView: View {
     @State private var showCompleted = false
@@ -51,6 +53,7 @@ struct AsyncButtonTestView: View {
         }
     }
 }
+
 
 #if DEBUG
 struct AsyncButtonTestView_Previews: PreviewProvider {

--- a/Tests/UITests/TestApp/ViewsTests/DefaultErrorDescriptionTestView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/DefaultErrorDescriptionTestView.swift
@@ -15,8 +15,10 @@ struct DefaultErrorDescriptionTestView: View {
     }
 }
 
+#if DEBUG
 struct DefaultErrorDescriptionTestView_Previews: PreviewProvider {
     static var previews: some View {
         DefaultErrorDescriptionTestView()
     }
 }
+#endif

--- a/Tests/UITests/TestApp/ViewsTests/HTMLViewTestView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/HTMLViewTestView.swift
@@ -26,8 +26,10 @@ struct HTMLViewTestView: View {
     }
 }
 
+#if DEBUG
 struct HTMLViewTestView_Previews: PreviewProvider {
     static var previews: some View {
         HTMLViewTestView()
     }
 }
+#endif

--- a/Tests/UITests/TestApp/ViewsTests/ViewStateTestView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/ViewStateTestView.swift
@@ -26,7 +26,8 @@ struct ViewStateTestView: View {
     )
     
     @State var viewState: ViewState = .idle
-    @Environment(\.defaultErrorDescription) var defaultErrorDescription
+    @Environment(\.defaultErrorDescription)
+    var defaultErrorDescription
     
     var body: some View {
         Text("View State: \(String(describing: viewState))")

--- a/Tests/UITests/TestAppUITests/EnvironmentTests.swift
+++ b/Tests/UITests/TestAppUITests/EnvironmentTests.swift
@@ -17,7 +17,7 @@ final class EnvironmentTests: XCTestCase {
 
         app.collectionViews.buttons["Default Error Description"].tap()
 
-        XCTAssert(app.staticTexts["View State: processing"].exists)
+        XCTAssert(app.staticTexts["View State: processing"].waitForExistence(timeout: 1))
 
         sleep(6)
 

--- a/Tests/UITests/TestAppUITests/ModelTests.swift
+++ b/Tests/UITests/TestAppUITests/ModelTests.swift
@@ -17,7 +17,7 @@ final class ModelTests: XCTestCase {
 
         app.collectionViews.buttons["View State"].tap()
 
-        XCTAssert(app.staticTexts["View State: processing"].exists)
+        XCTAssert(app.staticTexts["View State: processing"].waitForExistence(timeout: 1))
 
         sleep(6)
 
@@ -35,7 +35,7 @@ final class ModelTests: XCTestCase {
 
         app.collectionViews.buttons["Default Error Only"].tap()
 
-        XCTAssert(app.staticTexts["View State: processing"].exists)
+        XCTAssert(app.staticTexts["View State: processing"].waitForExistence(timeout: 1))
 
         sleep(6)
 

--- a/Tests/UITests/TestAppUITests/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/ViewsTests.swift
@@ -139,7 +139,7 @@ final class ViewsTests: XCTestCase {
         XCTAssert(app.collectionViews.buttons["Hello World"].exists)
         app.collectionViews.buttons["Hello World"].tap()
 
-        XCTAssert(app.collectionViews.staticTexts["Action exectued"].waitForExistence(timeout: 2))
+        XCTAssert(app.collectionViews.staticTexts["Action executed"].waitForExistence(timeout: 2))
         app.collectionViews.buttons["Reset"].tap()
 
         XCTAssert(app.collectionViews.buttons["Hello Throwing World"].exists)

--- a/Tests/UITests/TestAppUITests/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/ViewsTests.swift
@@ -47,7 +47,7 @@ final class ViewsTests: XCTestCase {
         
         app.collectionViews.buttons["Name Fields"].tap()
         
-        XCTAssert(app.staticTexts["First Title"].exists)
+        XCTAssert(app.staticTexts["First Title"].waitForExistence(timeout: 1))
         XCTAssert(app.staticTexts["Second Title"].exists)
         XCTAssert(app.staticTexts["First Name"].exists)
         XCTAssert(app.staticTexts["Last Name"].exists)
@@ -68,10 +68,10 @@ final class ViewsTests: XCTestCase {
         
         app.collectionViews.buttons["User Profile"].tap()
         
-        XCTAssertTrue(app.staticTexts["PS"].exists)
+        XCTAssertTrue(app.staticTexts["PS"].waitForExistence(timeout: 1))
         XCTAssertTrue(app.staticTexts["LS"].exists)
         
-        XCTAssertTrue(app.images["person.crop.artframe"].waitForExistence(timeout: 1.0))
+        XCTAssertTrue(app.images["person.crop.artframe"].waitForExistence(timeout: 3.5))
     }
     
     func testGeometryReader() throws {
@@ -89,6 +89,8 @@ final class ViewsTests: XCTestCase {
         app.launch()
         
         app.collectionViews.buttons["Label"].tap()
+
+        sleep(2)
         
         // The string value needs to be searched for in the UI.
         // swiftlint:disable:next line_length
@@ -102,7 +104,7 @@ final class ViewsTests: XCTestCase {
         
         app.collectionViews.buttons["Lazy Text"].tap()
         
-        XCTAssert(app.staticTexts["This is a long text ..."].exists)
+        XCTAssert(app.staticTexts["This is a long text ..."].waitForExistence(timeout: 1))
         XCTAssert(app.staticTexts["And some more lines ..."].exists)
         XCTAssert(app.staticTexts["And a third line ..."].exists)
     }
@@ -113,8 +115,8 @@ final class ViewsTests: XCTestCase {
         
         app.collectionViews.buttons["Markdown View"].tap()
         
-        XCTAssert(app.staticTexts["This is a markdown example."].exists)
-        
+        XCTAssert(app.staticTexts["This is a markdown example."].waitForExistence(timeout: 1))
+
         sleep(6)
         
         XCTAssert(app.staticTexts["This is a markdown example taking 5 seconds to load."].exists)
@@ -136,7 +138,7 @@ final class ViewsTests: XCTestCase {
 
         app.collectionViews.buttons["Async Button"].tap()
 
-        XCTAssert(app.collectionViews.buttons["Hello World"].exists)
+        XCTAssert(app.collectionViews.buttons["Hello World"].waitForExistence(timeout: 1))
         app.collectionViews.buttons["Hello World"].tap()
 
         XCTAssert(app.collectionViews.staticTexts["Action executed"].waitForExistence(timeout: 2))

--- a/Tests/UITests/TestAppUITests/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/ViewsTests.swift
@@ -129,4 +129,25 @@ final class ViewsTests: XCTestCase {
         XCTAssert(app.webViews.staticTexts["This is an HTML example."].waitForExistence(timeout: 15))
         XCTAssert(app.staticTexts["This is an HTML example taking 5 seconds to load."].waitForExistence(timeout: 10))
     }
+
+    func testAsyncButtonView() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        app.collectionViews.buttons["Async Button"].tap()
+
+        XCTAssert(app.collectionViews.buttons["Hello World"].exists)
+        app.collectionViews.buttons["Hello World"].tap()
+
+        XCTAssert(app.collectionViews.staticTexts["Action exectued"].waitForExistence(timeout: 2))
+        app.collectionViews.buttons["Reset"].tap()
+
+        XCTAssert(app.collectionViews.buttons["Hello Throwing World"].exists)
+        app.collectionViews.buttons["Hello Throwing World"].tap()
+
+        let alert = app.alerts.firstMatch.scrollViews.otherElements
+        XCTAssert(alert.staticTexts["Custom Error"].waitForExistence(timeout: 1))
+        XCTAssert(alert.staticTexts["Error was thrown!"].waitForExistence(timeout: 1))
+        alert.buttons["OK"].tap()
+    }
 }

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		A97880972A4C4E6500150B2F /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97880962A4C4E6500150B2F /* ModelTests.swift */; };
 		A97880992A4C524D00150B2F /* DefaultErrorDescriptionTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97880982A4C524D00150B2F /* DefaultErrorDescriptionTestView.swift */; };
 		A978809B2A4C52F100150B2F /* EnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A978809A2A4C52F100150B2F /* EnvironmentTests.swift */; };
+		A998A94F2A609A9E0030624D /* AsyncButtonTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A998A94E2A609A9E0030624D /* AsyncButtonTestView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,6 +54,7 @@
 		A97880962A4C4E6500150B2F /* ModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
 		A97880982A4C524D00150B2F /* DefaultErrorDescriptionTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultErrorDescriptionTestView.swift; sourceTree = "<group>"; };
 		A978809A2A4C52F100150B2F /* EnvironmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnvironmentTests.swift; sourceTree = "<group>"; };
+		A998A94E2A609A9E0030624D /* AsyncButtonTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncButtonTestView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -135,6 +137,7 @@
 				2FA9486329DE90720081C086 /* GeometryReaderTestView.swift */,
 				2FA9486429DE90720081C086 /* HTMLViewTestView.swift */,
 				A97880982A4C524D00150B2F /* DefaultErrorDescriptionTestView.swift */,
+				A998A94E2A609A9E0030624D /* AsyncButtonTestView.swift */,
 			);
 			path = ViewsTests;
 			sourceTree = "<group>";
@@ -252,6 +255,7 @@
 				2FA9486B29DE90720081C086 /* HTMLViewTestView.swift in Sources */,
 				2FA9486529DE90720081C086 /* ViewStateTestView.swift in Sources */,
 				2FA9486929DE90720081C086 /* NameFieldsTestView.swift in Sources */,
+				A998A94F2A609A9E0030624D /* AsyncButtonTestView.swift in Sources */,
 				2FA9486A29DE90720081C086 /* GeometryReaderTestView.swift in Sources */,
 				2FA9486729DE90720081C086 /* CanvasTestView.swift in Sources */,
 				2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */,

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -656,7 +656,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/XCTestExtensions.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.5;
+				minimumVersion = 0.4.6;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SpeziViews"
+               BuildableName = "SpeziViews"
+               BlueprintName = "SpeziViews"
+               ReferencedContainer = "container:../..">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2F6D139128F5F384007C25D6"
+               BuildableName = "TestApp.app"
+               BlueprintName = "TestApp"
+               ReferencedContainer = "container:UITests.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2F6D13AB28F5F386007C25D6"
+               BuildableName = "TestAppUITests.xctest"
+               BlueprintName = "TestAppUITests"
+               ReferencedContainer = "container:UITests.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2F6D139128F5F384007C25D6"
+            BuildableName = "TestApp.app"
+            BlueprintName = "TestApp"
+            ReferencedContainer = "container:UITests.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2F6D139128F5F384007C25D6"
+            BuildableName = "TestApp.app"
+            BlueprintName = "TestApp"
+            ReferencedContainer = "container:UITests.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
<!--

This source file is part of the Stanford Spezi open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Implement a generic AsyncButton with support for throwing closures

## :recycle: Current situation & Problem
Currently, Spezi Views (nor SwiftUI) provide a way to easily manage buttons with asynchronous action closures. We have several use cases where a reusable button with an async (throwing) action closure would be helpful (e.g. SpeziAccount for Login/Signup/Password Reset buttons).

## :bulb: Proposed solution

This PR introduces a the new, reusable component `AsyncButton` that allows to supply `async` and `async throwing` action closures. It handles disabling the button and rendering of a processing indicator automatically. To deal with thrown errors of the action closure, we reuse the `ViewState` abstraction already available in SpeziViews. This can easily be combined with the `viewStateAlert(state:)` modifier to display a simple error alert. 


## :gear: Release Notes 

* Added a `AsyncButton` component for `async` and `async throwing` action closures.
* Added the `processingDebounceDuration` EnvironmentKey for a generalized configuration of debounce durations.
* Added the `processingOverlay(isProcessing:overlay)` modifier to easily replace a view with a processing indicator.

## :heavy_plus_sign: Additional Information

### Related PRs
This PR refines the `AsyncDataEntrySubmitButton` implementation currently used in the upcoming SpeziAccount  PR https://github.com/StanfordSpezi/SpeziAccount/pull/7 and moves it to SpeziViews.

### Testing
Additional UI tests were added.

### Reviewer Nudging
Ideally, have a look at the added UI tests and then at the `AsyncButton` implementation itself. It might be helpful to play around with the Previews of `AsyncButton` as well.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
