### PR TITLE
Improve Localization and Explicit Initializers Without Localization

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,6 +27,7 @@ jobs:
     name: Build and Test UI Tests
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
+      xcodeversion: latest
       artifactname: TestApp.xcresult
       runsonlabels: '["macOS", "self-hosted"]'
       path: 'Tests/UITests'

--- a/Sources/SpeziViews/Environment/DefaultErrorDescription.swift
+++ b/Sources/SpeziViews/Environment/DefaultErrorDescription.swift
@@ -18,6 +18,7 @@ public struct DefaultErrorDescription: EnvironmentKey {
     public static let defaultValue: LocalizedStringResource? = nil
 }
 
+
 extension EnvironmentValues {
     /// Refer to the documentation of ``DefaultErrorDescription``.
     public var defaultErrorDescription: LocalizedStringResource? {

--- a/Sources/SpeziViews/Model/FieldLocalizationResource.swift
+++ b/Sources/SpeziViews/Model/FieldLocalizationResource.swift
@@ -32,7 +32,12 @@ public struct FieldLocalizationResource: Codable {
     ///   - placeholder: The placeholder of a `TextField` following the localization mechanisms lined out in `StringProtocol.localized()`.
     ///   - bundle: The `Bundle` used for localization. If you have differing bundles for title and placeholder use the
     ///     alternative initializer ``init(title:placeholder:)``.
-    public init(title: String, placeholder: String, bundle: Bundle? = nil) {
+    @_disfavoredOverload
+    public init<Title: StringProtocol, Placeholder: StringProtocol>(
+        title: Title,
+        placeholder: Placeholder,
+        bundle: Bundle? = nil
+    ) {
         self.init(title: title.localized(bundle), placeholder: placeholder.localized(bundle))
     }
 }

--- a/Sources/SpeziViews/Model/ViewState.swift
+++ b/Sources/SpeziViews/Model/ViewState.swift
@@ -19,8 +19,8 @@ public enum ViewState {
     case error(LocalizedError)
 }
 
-// MARK: - ViewState Extensions
 
+// MARK: - ViewState Extensions
 extension ViewState: Equatable {
     public static func == (lhs: ViewState, rhs: ViewState) -> Bool {
         switch (lhs, rhs) {
@@ -31,6 +31,7 @@ extension ViewState: Equatable {
         }
     }
 }
+
 
 // MARK: - ViewState + Error
 extension ViewState {

--- a/Sources/SpeziViews/Utilities/StringProtocol+Localization.swift
+++ b/Sources/SpeziViews/Utilities/StringProtocol+Localization.swift
@@ -26,7 +26,7 @@ extension StringProtocol {
     /// `String` instances are not localized. You have to manually localize a `String` instance using `String(localized:)`.
     public func localized(_ bundle: Bundle? = nil) -> LocalizedStringResource {
         let bundleDescription = bundle.map { LocalizedStringResource.BundleDescription.atURL(from: $0) } ?? .main
-
+        
         switch self {
         case let text as String.LocalizationValue:
             return LocalizedStringResource(text, bundle: bundleDescription)

--- a/Sources/SpeziViews/Views/Button/AsyncButton.swift
+++ b/Sources/SpeziViews/Views/Button/AsyncButton.swift
@@ -84,6 +84,24 @@ public struct AsyncButton<Label: View>: View {
 
     /// Creates an async throwing button that generates its label from a provided localized string.
     /// - Parameters:
+    ///   - title: The string without localization used to generate the Label.
+    ///   - role: An optional button role that is passed onto the underlying `Button`.
+    ///   - state: A ``ViewState`` binding that it used to propagate any error caught in the button action.
+    ///         It may also be used to externally control or observe the button's processing state.
+    ///   - action: An asynchronous button action.
+    public init<S: StringProtocol>( // swiftlint:disable:this function_default_parameter_at_end
+        _ title: S,
+        role: ButtonRole? = nil,
+        state: Binding<ViewState>,
+        action: @escaping () async throws -> Void
+    ) where Label == Text {
+        self.init(role: role, state: state, action: action) {
+            Text(title)
+        }
+    }
+    
+    /// Creates an async throwing button that generates its label from a provided localized string.
+    /// - Parameters:
     ///   - title: The localized string used to generate the Label.
     ///   - role: An optional button role that is passed onto the underlying `Button`.
     ///   - state: A ``ViewState`` binding that it used to propagate any error caught in the button action.

--- a/Sources/SpeziViews/Views/Button/AsyncButton.swift
+++ b/Sources/SpeziViews/Views/Button/AsyncButton.swift
@@ -50,7 +50,6 @@ public struct AsyncButton<Label: View>: View {
             }
     }
 
-
     /// Creates am async button that generates its label from a provided localized string.
     /// - Parameters:
     ///   - title: The localized string used to generate the Label.
@@ -58,6 +57,22 @@ public struct AsyncButton<Label: View>: View {
     ///   - action: An asynchronous button action.
     public init(
         _ title: LocalizedStringResource,
+        role: ButtonRole? = nil,
+        action: @escaping () async -> Void
+    ) where Label == Text {
+        self.init(role: role, action: action) {
+            Text(title)
+        }
+    }
+    
+    /// Creates am async button that generates its label from a provided without localization.
+    /// - Parameters:
+    ///   - title: The string used to generate the Label without localization.
+    ///   - role: An optional button role that is passed onto the underlying `Button`.
+    ///   - action: An asynchronous button action.
+    @_disfavoredOverload
+    public init<Title: StringProtocol>(
+        _ title: Title,
         role: ButtonRole? = nil,
         action: @escaping () async -> Void
     ) where Label == Text {
@@ -82,15 +97,16 @@ public struct AsyncButton<Label: View>: View {
         self._viewState = .constant(.idle)
     }
 
-    /// Creates an async throwing button that generates its label from a provided localized string.
+    /// Creates an async throwing button that generates its label from a provided without localization.
     /// - Parameters:
     ///   - title: The string without localization used to generate the Label.
     ///   - role: An optional button role that is passed onto the underlying `Button`.
     ///   - state: A ``ViewState`` binding that it used to propagate any error caught in the button action.
     ///         It may also be used to externally control or observe the button's processing state.
     ///   - action: An asynchronous button action.
-    public init<S: StringProtocol>( // swiftlint:disable:this function_default_parameter_at_end
-        _ title: S,
+    @_disfavoredOverload
+    public init<Title: StringProtocol>( // swiftlint:disable:this function_default_parameter_at_end
+        _ title: Title,
         role: ButtonRole? = nil,
         state: Binding<ViewState>,
         action: @escaping () async throws -> Void

--- a/Sources/SpeziViews/Views/Text/Label.swift
+++ b/Sources/SpeziViews/Views/Text/Label.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+import Foundation
 import SwiftUI
 
 
@@ -67,9 +68,9 @@ public struct Label: View {
     }
     
     
-    /// Creates a new instance of the SwiftUI-based wrapper around a `UILabel`.
+    /// Creates a new localized instance of the SwiftUI-based wrapper around a `UILabel`.
     /// - Parameters:
-    ///   - text: The text that should be displayed.
+    ///   - text: The localized text that should be displayed.
     ///   - textStyle: The `UIFont.TextStyle` of the `UILabel`. Defaults to `.body`.
     ///   - textAlignment: The `NSTextAlignment` of the `UILabel`. Defaults to `.justified`.
     ///   - textColor: The `UIColor` of the `UILabel`. Defaults to `.label`.
@@ -95,8 +96,9 @@ public struct Label: View {
     ///   - textAlignment: The `NSTextAlignment` of the `UILabel`. Defaults to `.justified`.
     ///   - textColor: The `UIColor` of the `UILabel`. Defaults to `.label`.
     ///   - numberOfLines: The number of lines allowed of the `UILabel`. Defaults to 0 indicating no limit.
-    public init<S: StringProtocol>(
-        _ text: S,
+    @_disfavoredOverload
+    public init<Text: StringProtocol>(
+        _ text: Text,
         textStyle: UIFont.TextStyle = .body,
         textAlignment: NSTextAlignment = .justified,
         textColor: UIColor = .label,

--- a/Sources/SpeziViews/Views/Text/Label.swift
+++ b/Sources/SpeziViews/Views/Text/Label.swift
@@ -75,13 +75,34 @@ public struct Label: View {
     ///   - textColor: The `UIColor` of the `UILabel`. Defaults to `.label`.
     ///   - numberOfLines: The number of lines allowed of the `UILabel`. Defaults to 0 indicating no limit.
     public init(
-        _ text: String,
+        _ text: LocalizedStringResource,
         textStyle: UIFont.TextStyle = .body,
         textAlignment: NSTextAlignment = .justified,
         textColor: UIColor = .label,
         numberOfLines: Int = 0
     ) {
-        self.text = text
+        self.text = text.localizedString()
+        self.textStyle = textStyle
+        self.textAlignment = textAlignment
+        self.textColor = textColor
+        self.numberOfLines = numberOfLines
+    }
+    
+    /// Creates a new instance of the SwiftUI-based wrapper around a `UILabel` without localization.
+    /// - Parameters:
+    ///   - text: The text that should be displayed without localization.
+    ///   - textStyle: The `UIFont.TextStyle` of the `UILabel`. Defaults to `.body`.
+    ///   - textAlignment: The `NSTextAlignment` of the `UILabel`. Defaults to `.justified`.
+    ///   - textColor: The `UIColor` of the `UILabel`. Defaults to `.label`.
+    ///   - numberOfLines: The number of lines allowed of the `UILabel`. Defaults to 0 indicating no limit.
+    public init<S: StringProtocol>(
+        _ text: S,
+        textStyle: UIFont.TextStyle = .body,
+        textAlignment: NSTextAlignment = .justified,
+        textColor: UIColor = .label,
+        numberOfLines: Int = 0
+    ) {
+        self.text = String(text)
         self.textStyle = textStyle
         self.textAlignment = textAlignment
         self.textColor = textColor

--- a/Sources/SpeziViews/Views/Text/LazyText.swift
+++ b/Sources/SpeziViews/Views/Text/LazyText.swift
@@ -36,7 +36,8 @@ public struct LazyText: View {
     
     /// A lazy loading text view that is especially useful for larger text files that should not be displayed all at once.
     /// - Parameter text: The text without localization that should be displayed in the ``LazyText`` view.
-    public init<S: StringProtocol>(text: S) {
+    @_disfavoredOverload
+    public init<Text: StringProtocol>(text: Text) {
         self.text = String(text)
     }
     

--- a/Sources/SpeziViews/Views/Text/LazyText.swift
+++ b/Sources/SpeziViews/Views/Text/LazyText.swift
@@ -35,9 +35,15 @@ public struct LazyText: View {
     
     
     /// A lazy loading text view that is especially useful for larger text files that should not be displayed all at once.
+    /// - Parameter text: The text without localization that should be displayed in the ``LazyText`` view.
+    public init<S: StringProtocol>(text: S) {
+        self.text = String(text)
+    }
+    
+    /// A lazy loading text view that is especially useful for larger text files that should not be displayed all at once.
     /// - Parameter text: The text that should be displayed in the ``LazyText`` view.
-    public init(text: String) {
-        self.text = text
+    public init(text: LocalizedStringResource) {
+        self.text = text.localizedString()
     }
 }
 

--- a/Tests/UITests/TestApp/Localizable.xcstrings
+++ b/Tests/UITests/TestApp/Localizable.xcstrings
@@ -1,0 +1,87 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "%lf" : {
+
+    },
+    "Action executed" : {
+
+    },
+    "Did Draw Anything: %@" : {
+
+    },
+    "Error Description" : {
+
+    },
+    "First Placeholder" : {
+
+    },
+    "First Title" : {
+
+    },
+    "Hello Throwing World" : {
+
+    },
+    "HELLO_WORLD" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hallo Welt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hello World"
+          }
+        }
+      }
+    },
+    "LABEL_TEXT" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This is a label ...\nAn other text. This is longer and we can check if the justified text works as expected. This is a very long text."
+          }
+        }
+      }
+    },
+    "LAZY_TEXT" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "An other lazy text ..."
+          }
+        }
+      }
+    },
+    "Reset" : {
+
+    },
+    "Second Placeholder" : {
+
+    },
+    "Second Title" : {
+
+    },
+    "Show Tool Picker" : {
+
+    },
+    "This is a default error description!" : {
+
+    },
+    "This is a label ...\nAn other text. This is longer and we can check if the justified text works as expected. This is a very long text." : {
+
+    },
+    "This is a long text ...\n\nAnd some more lines ...\n\nAnd a third line ..." : {
+
+    },
+    "View State: %@" : {
+
+    }
+  },
+  "version" : "1.0"
+}

--- a/Tests/UITests/TestApp/Localizable.xcstrings.license
+++ b/Tests/UITests/TestApp/Localizable.xcstrings.license
@@ -1,0 +1,5 @@
+This source file is part of the Stanford Spezi open-source project
+
+SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT

--- a/Tests/UITests/TestApp/SpeziViewsTests.swift
+++ b/Tests/UITests/TestApp/SpeziViewsTests.swift
@@ -59,7 +59,8 @@ enum SpeziViewsTests: String, TestAppTests {
     
     @ViewBuilder
     private var label: some View {
-        Label("LABEL_TEXT",
+        Label(
+            "LABEL_TEXT",
             textAlignment: .justified,
             textColor: .blue
         )

--- a/Tests/UITests/TestApp/SpeziViewsTests.swift
+++ b/Tests/UITests/TestApp/SpeziViewsTests.swift
@@ -59,11 +59,7 @@ enum SpeziViewsTests: String, TestAppTests {
     
     @ViewBuilder
     private var label: some View {
-        Label(
-            """
-            This is a label ...
-            An other text. This is longer and we can check if the justified text works as expected. This is a very long text.
-            """,
+        Label("LABEL_TEXT",
             textAlignment: .justified,
             textColor: .blue
         )
@@ -101,6 +97,7 @@ enum SpeziViewsTests: String, TestAppTests {
                 And a third line ...
                 """
             )
+            LazyText(text: "LAZY_TEXT")
         }
     }
     

--- a/Tests/UITests/TestApp/ViewsTests/AsyncButtonTestView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/AsyncButtonTestView.swift
@@ -38,11 +38,10 @@ struct AsyncButtonTestView: View {
                 }
             }
             Group {
-                AsyncButton("Hello World") {
+                AsyncButton("HELLO_WORLD") {
                     try? await Task.sleep(for: .milliseconds(500))
                     showCompleted = true
                 }
-
                 AsyncButton("Hello Throwing World", role: .destructive, state: $viewState) {
                     try? await Task.sleep(for: .milliseconds(500))
                     throw CustomError.error

--- a/Tests/UITests/TestAppUITests/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/ViewsTests.swift
@@ -21,8 +21,8 @@ final class ViewsTests: XCTestCase {
         
         app.collectionViews.buttons["Canvas"].tap()
         
-        XCTAssert(app.staticTexts["Did Draw Anything: false"].waitForExistence(timeout: 1))
-        XCTAssertFalse(app.scrollViews.otherElements.images["palette_tool_pencil_base"].waitForExistence(timeout: 1))
+        XCTAssert(app.staticTexts["Did Draw Anything: false"].waitForExistence(timeout: 2))
+        XCTAssertFalse(app.scrollViews.otherElements.images["palette_tool_pencil_base"].waitForExistence(timeout: 2))
         
         let canvasView = app.scrollViews.firstMatch
         canvasView.swipeRight()
@@ -30,14 +30,16 @@ final class ViewsTests: XCTestCase {
         
         XCTAssert(app.staticTexts["Did Draw Anything: true"].exists)
         
+        XCTAssert(app.buttons["Show Tool Picker"].waitForExistence(timeout: 2))
         app.buttons["Show Tool Picker"].tap()
         
-        XCTAssert(app.scrollViews.otherElements.images["palette_tool_pencil_base"].waitForExistence(timeout: 1))
+        XCTAssert(app.scrollViews.otherElements.images["palette_tool_pencil_base"].waitForExistence(timeout: 2))
         canvasView.swipeLeft()
         
+        XCTAssert(app.buttons["Show Tool Picker"].waitForExistence(timeout: 2))
         app.buttons["Show Tool Picker"].tap()
         
-        XCTAssertFalse(app.scrollViews.otherElements.images["palette_tool_pencil_base"].waitForExistence(timeout: 1))
+        XCTAssertFalse(app.scrollViews.otherElements.images["palette_tool_pencil_base"].waitForExistence(timeout: 2))
         canvasView.swipeUp()
     }
     

--- a/Tests/UITests/TestAppUITests/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/ViewsTests.swift
@@ -107,6 +107,7 @@ final class ViewsTests: XCTestCase {
         XCTAssert(app.staticTexts["This is a long text ..."].waitForExistence(timeout: 1))
         XCTAssert(app.staticTexts["And some more lines ..."].exists)
         XCTAssert(app.staticTexts["And a third line ..."].exists)
+        XCTAssert(app.staticTexts["An other lazy text ..."].exists)
     }
     
     func testMarkdownView() throws {

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		2FA9486F29DE91A30081C086 /* SpeziViews in Frameworks */ = {isa = PBXBuildFile; productRef = 2FA9486E29DE91A30081C086 /* SpeziViews */; };
 		2FA9487129DE91CC0081C086 /* XCTestApp in Frameworks */ = {isa = PBXBuildFile; productRef = 2FA9487029DE91CC0081C086 /* XCTestApp */; };
 		2FA9487329DE92410081C086 /* XCTestExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 2FA9487229DE92410081C086 /* XCTestExtensions */; };
+		2FB099B82A8AD25300B20952 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 2FB099B72A8AD25100B20952 /* Localizable.xcstrings */; };
 		A97880972A4C4E6500150B2F /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97880962A4C4E6500150B2F /* ModelTests.swift */; };
 		A97880992A4C524D00150B2F /* DefaultErrorDescriptionTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97880982A4C524D00150B2F /* DefaultErrorDescriptionTestView.swift */; };
 		A978809B2A4C52F100150B2F /* EnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A978809A2A4C52F100150B2F /* EnvironmentTests.swift */; };
@@ -51,6 +52,7 @@
 		2FA9486429DE90720081C086 /* HTMLViewTestView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLViewTestView.swift; sourceTree = "<group>"; };
 		2FA9486C29DE91130081C086 /* ViewsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewsTests.swift; sourceTree = "<group>"; };
 		2FB0758A299DDB9000C0B37F /* TestApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestApp.xctestplan; sourceTree = "<group>"; };
+		2FB099B72A8AD25100B20952 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		A97880962A4C4E6500150B2F /* ModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
 		A97880982A4C524D00150B2F /* DefaultErrorDescriptionTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultErrorDescriptionTestView.swift; sourceTree = "<group>"; };
 		A978809A2A4C52F100150B2F /* EnvironmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnvironmentTests.swift; sourceTree = "<group>"; };
@@ -106,6 +108,7 @@
 				2F2D338629DE52EA00081B1D /* SpeziViewsTests.swift */,
 				2FA9485D29DE90710081C086 /* ViewsTests */,
 				2F6D139928F5F386007C25D6 /* Assets.xcassets */,
+				2FB099B72A8AD25100B20952 /* Localizable.xcstrings */,
 			);
 			path = TestApp;
 			sourceTree = "<group>";
@@ -234,6 +237,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2FB099B82A8AD25300B20952 /* Localizable.xcstrings in Resources */,
 				2F6D139A28F5F386007C25D6 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
# Improve Localization and Explicit Initializers Without Localization

## :bulb: Current situation & Proposed solution
- Aligns the initializers with the SwiftUI initializers for e.g. `Text` and `Button`:
  - https://developer.apple.com/documentation/swiftui/text#creating-a-text-view-from-a-string
  - https://developer.apple.com/documentation/swiftui/button#creating-a-button

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
