### PR TITLE
Fixed a race condition that could render an async button disabled forever in the erroneous case

### DIFF
--- a/Tests/UITests/TestApp/ViewsTests/AsyncButtonTestView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/AsyncButtonTestView.swift
@@ -38,12 +38,12 @@ struct AsyncButtonTestView: View {
                 }
             }
             Group {
-                AsyncButton("HELLO_WORLD") {
+                AsyncButton("Hello World") {
                     try? await Task.sleep(for: .milliseconds(500))
                     showCompleted = true
                 }
                 AsyncButton("Hello Throwing World", role: .destructive, state: $viewState) {
-                    try? await Task.sleep(for: .milliseconds(500))
+                    try await Task.sleep(for: .milliseconds(20))
                     throw CustomError.error
                 }
             }

--- a/Tests/UITests/TestAppUITests/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/ViewsTests.swift
@@ -154,5 +154,7 @@ final class ViewsTests: XCTestCase {
         XCTAssert(alert.staticTexts["Custom Error"].waitForExistence(timeout: 1))
         XCTAssert(alert.staticTexts["Error was thrown!"].waitForExistence(timeout: 1))
         alert.buttons["OK"].tap()
+
+        XCTAssert(app.collectionViews.buttons["Hello Throwing World"].isEnabled)
     }
 }

--- a/Tests/UITests/TestAppUITests/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/ViewsTests.swift
@@ -39,6 +39,7 @@ final class ViewsTests: XCTestCase {
         XCTAssert(app.buttons["Show Tool Picker"].waitForExistence(timeout: 2))
         app.buttons["Show Tool Picker"].tap()
         
+        sleep(2) // waitForExistence will otherwise return immediately
         XCTAssertFalse(app.scrollViews.otherElements.images["palette_tool_pencil_base"].waitForExistence(timeout: 2))
         canvasView.swipeUp()
     }


### PR DESCRIPTION


<!--

This source file is part of the Stanford Spezi open-source project

SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Fixed a race condition that could render an async button disabled forever in the erroneous case

## :recycle: Current situation & Problem
An `AsyncButton` renders a loading indicator to visualize the loading process of the async action closure. However, this loading is rendered delay by 150ms (by default, controlled via the `\.processingDebounceDuration` environment key). There was found a race condition, where this rendering state was rendered forever when the async closure returned with an error before the 150ms processing debounce duration.

## :gear: Release Notes 
* Fixed a race condition that could render an async button disabled forever in the erroneous case


## :books: Documentation
Documentation is not affected by this bug fix.


## :white_check_mark: Testing
Test cases were addressed to verify this execution path is now handled correctly.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
