### PR TITLE
Allow for more customizable labels for DescriptionGridRow and NameFields, pass FocusState as Binding

### DIFF
--- a/Sources/SpeziViews/Utilities/LocalizedStringResource+String.swift
+++ b/Sources/SpeziViews/Utilities/LocalizedStringResource+String.swift
@@ -18,7 +18,6 @@ extension LocalizedStringResource {
             resource.locale = locale
             return String(localized: resource)
         }
-
         return String(localized: self)
     }
 }

--- a/Sources/SpeziViews/Utilities/LocalizedStringResource+String.swift
+++ b/Sources/SpeziViews/Utilities/LocalizedStringResource+String.swift
@@ -10,7 +10,15 @@ import Foundation
 
 extension LocalizedStringResource {
     /// Creates a localized `String` from the given `LocalizedStringResource`.
-    public func localizedString() -> String {
-        String(localized: self)
+    /// - Parameter locale: Specifies an override locale.
+    /// - Returns: The localized string.
+    public func localizedString(for locale: Locale? = nil) -> String {
+        if let locale {
+            var resource = self
+            resource.locale = locale
+            return String(localized: resource)
+        }
+
+        return String(localized: self)
     }
 }

--- a/Sources/SpeziViews/ViewModifier/OnTapFocus.swift
+++ b/Sources/SpeziViews/ViewModifier/OnTapFocus.swift
@@ -9,25 +9,27 @@
 import SwiftUI
 
 
+private struct UUIDOnTapFocus: ViewModifier {
+    @FocusState var focusedState: UUID?
+
+    func body(content: Content) -> some View {
+        content
+            .onTapFocus(focusedField: $focusedState, fieldIdentifier: UUID())
+    }
+}
+
+
 private struct OnTapFocus<FocusedField: Hashable>: ViewModifier {
     private let fieldIdentifier: FocusedField
-    
-    @FocusState private var focusedState: FocusedField?
-    
+
+    @FocusState.Binding var focusedState: FocusedField?
     
     init(
-        focusedState: FocusState<FocusedField?>,
+        focusedState: FocusState<FocusedField?>.Binding,
         fieldIdentifier: FocusedField
     ) {
         self._focusedState = focusedState
         self.fieldIdentifier = fieldIdentifier
-    }
-    
-    init() where FocusedField == UUID {
-        self.init(
-            focusedState: FocusState<FocusedField?>(),
-            fieldIdentifier: UUID()
-        )
     }
     
     
@@ -44,17 +46,29 @@ private struct OnTapFocus<FocusedField: Hashable>: ViewModifier {
 extension View {
     /// Modifies the view to be in a focused state (e.g., `TextFields`) if it is tapped.
     public func onTapFocus() -> some View {
-        modifier(OnTapFocus())
+        modifier(UUIDOnTapFocus())
+    }
+
+    /// Modifies the view to be in a focused state (e.g., `TextFields`) if it is tapped.
+    /// - Parameters:
+    ///   - focusedField: The `FocusState` binding that should be set.
+    ///   - fieldIdentifier: The identifier that the `focusedField` should be set to.
+    public func onTapFocus<FocusedField: Hashable>(
+        focusedField: FocusState<FocusedField?>.Binding,
+        fieldIdentifier: FocusedField
+    ) -> some View {
+        modifier(OnTapFocus(focusedState: focusedField, fieldIdentifier: fieldIdentifier))
     }
     
     /// Modifies the view to be in a focused state (e.g., `TextFields`) if it is tapped.
     /// - Parameters:
     ///   - focusedField: The `FocusState` binding that should be set.
     ///   - fieldIdentifier: The identifier that the `focusedField` should be set to.
+    @available(*, deprecated, message: "Please move to the onTapFocus(focusedField:fieldIdentifier:) that accepts the FocusState as a Binding.")
     public func onTapFocus<FocusedField: Hashable>(
         focusedField: FocusState<FocusedField?>,
         fieldIdentifier: FocusedField
     ) -> some View {
-        modifier(OnTapFocus(focusedState: focusedField, fieldIdentifier: fieldIdentifier))
+        modifier(OnTapFocus(focusedState: focusedField.projectedValue, fieldIdentifier: fieldIdentifier))
     }
 }

--- a/Sources/SpeziViews/Views/DescriptionGridRow.swift
+++ b/Sources/SpeziViews/Views/DescriptionGridRow.swift
@@ -18,7 +18,6 @@ public struct DescriptionGridRow<Description: View, Content: View>: View {
     public var body: some View {
         GridRow {
             description
-                .fontWeight(.semibold)
                 .gridColumnAlignment(.leading)
                 .fixedSize(horizontal: false, vertical: true)
             content

--- a/Sources/SpeziViews/Views/Fields/NameFieldRow.swift
+++ b/Sources/SpeziViews/Views/Fields/NameFieldRow.swift
@@ -1,0 +1,101 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+
+struct FieldFocus<FocusedField: Hashable>: DynamicProperty {
+    let focusedState: FocusState<FocusedField?>.Binding
+    let fieldIdentifier: FocusedField
+}
+
+
+struct NameFieldRow<Label: View, FocusedField: Hashable>: View {
+    private let label: Label
+    private let placeholder: LocalizedStringResource
+
+    private let nameComponent: WritableKeyPath<PersonNameComponents, String?>
+    private let contentType: UITextContentType
+
+    private let fieldFocus: FieldFocus<FocusedField>?
+
+
+    @Binding private var name: PersonNameComponents
+
+    private var componentBinding: Binding<String> {
+        Binding {
+            name[keyPath: nameComponent] ?? ""
+        } set: { newValue in
+            name[keyPath: nameComponent] = newValue
+        }
+    }
+
+
+    var body: some View {
+        let row = DescriptionGridRow {
+            label
+        } content: {
+            TextField(text: componentBinding) {
+                Text(placeholder)
+            }
+                .autocorrectionDisabled(true)
+                .textInputAutocapitalization(.never)
+                .textContentType(contentType)
+        }
+
+        if let fieldFocus {
+            row
+                .onTapFocus(focusedField: fieldFocus.focusedState, fieldIdentifier: fieldFocus.fieldIdentifier)
+        } else {
+            row
+                .onTapFocus()
+        }
+    }
+
+
+    init(
+        _ placeholder: LocalizedStringResource,
+        name: Binding<PersonNameComponents>,
+        for nameComponent: WritableKeyPath<PersonNameComponents, String?>,
+        content contentType: UITextContentType,
+        @ViewBuilder label: () -> Label
+    ) where FocusedField == UUID {
+        self.init(placeholder, name: name, for: nameComponent, content: contentType, focus: nil, label: label)
+    }
+
+    init(
+        _ placeholder: LocalizedStringResource,
+        name: Binding<PersonNameComponents>,
+        for nameComponent: WritableKeyPath<PersonNameComponents, String?>,
+        content contentType: UITextContentType,
+        focus fieldFocus: FieldFocus<FocusedField>?,
+        @ViewBuilder label: () -> Label
+    ) {
+        self.placeholder = placeholder
+        self._name = name
+        self.nameComponent = nameComponent
+        self.contentType = contentType
+        self.fieldFocus = fieldFocus
+        self.label = label()
+    }
+}
+
+
+#if DEBUG
+struct NameFieldRow_Previews: PreviewProvider {
+    @State private static var name = PersonNameComponents()
+
+    static var previews: some View {
+        Grid {
+            NameFieldRow("First Name", name: $name, for: \.givenName, content: .givenName) {
+                Text("Enter first name ...")
+            }
+        }
+    }
+}
+#endif

--- a/Sources/SpeziViews/Views/Fields/NameFieldRow.swift
+++ b/Sources/SpeziViews/Views/Fields/NameFieldRow.swift
@@ -50,7 +50,10 @@ struct NameFieldRow<Label: View, FocusedField: Hashable>: View {
 
         if let fieldFocus {
             row
-                .onTapFocus(focusedField: fieldFocus.focusedState, fieldIdentifier: fieldFocus.fieldIdentifier)
+                .onTapFocus(
+                    focusedField: fieldFocus.focusedState,
+                    fieldIdentifier: fieldFocus.fieldIdentifier
+                )
         } else {
             row
                 .onTapFocus()

--- a/Sources/SpeziViews/Views/Fields/NameFields.swift
+++ b/Sources/SpeziViews/Views/Fields/NameFields.swift
@@ -72,7 +72,7 @@ public struct NameFields<GivenNameLabel: View, FamilyNameLabel: View, FocusedFie
         givenNameFieldIdentifier: FocusedField,
         familyNameField: FieldLocalizationResource = LocalizationDefaults.familyName,
         familyNameFieldIdentifier: FocusedField,
-        focusedState: FocusState<FocusedField?>.Binding // TODO breaking change!
+        focusedState: FocusState<FocusedField?>.Binding
     ) where GivenNameLabel == Text, FamilyNameLabel == Text {
         self.init(
             name: name,

--- a/Sources/SpeziViews/Views/Text/Label.swift
+++ b/Sources/SpeziViews/Views/Text/Label.swift
@@ -47,17 +47,19 @@ private struct _Label: UIViewRepresentable {
 
 /// A ``Label`` is a SwiftUI-based wrapper around a `UILabel` that allows the usage of an `NSTextAlignment` to e.g. justify the text.
 public struct Label: View {
-    private let text: String
+    private let text: LocalizedStringResource
     private let textStyle: UIFont.TextStyle
     private let textAlignment: NSTextAlignment
     private let textColor: UIColor
     private let numberOfLines: Int
+
+    @Environment(\.locale) private var locale
     
     
     public var body: some View {
         HorizontalGeometryReader { width in
             _Label(
-                text: text,
+                text: text.localizedString(for: locale),
                 textStyle: textStyle,
                 textAlignment: textAlignment,
                 textColor: textColor,
@@ -82,7 +84,7 @@ public struct Label: View {
         textColor: UIColor = .label,
         numberOfLines: Int = 0
     ) {
-        self.text = text.localizedString()
+        self.text = text
         self.textStyle = textStyle
         self.textAlignment = textAlignment
         self.textColor = textColor
@@ -104,7 +106,7 @@ public struct Label: View {
         textColor: UIColor = .label,
         numberOfLines: Int = 0
     ) {
-        self.text = String(text)
+        self.text = LocalizedStringResource("\(String(text))")
         self.textStyle = textStyle
         self.textAlignment = textAlignment
         self.textColor = textColor

--- a/Sources/SpeziViews/Views/Text/LazyText.swift
+++ b/Sources/SpeziViews/Views/Text/LazyText.swift
@@ -13,12 +13,14 @@ import SwiftUI
 ///
 /// Uses a `LazyVStack` under the hood to load and display the text line-by-line.
 public struct LazyText: View {
-    private let text: String
+    private let text: LocalizedStringResource
+
+    @Environment(\.locale) private var locale
     
     
     private var lines: [(id: UUID, text: String)] {
         var lines: [(id: UUID, text: String)] = []
-        text.enumerateLines { line, _ in
+        text.localizedString(for: locale).enumerateLines { line, _ in
             lines.append((UUID(), line))
         }
         return lines
@@ -38,13 +40,13 @@ public struct LazyText: View {
     /// - Parameter text: The text without localization that should be displayed in the ``LazyText`` view.
     @_disfavoredOverload
     public init<Text: StringProtocol>(text: Text) {
-        self.text = String(text)
+        self.text = LocalizedStringResource("\(String(text))")
     }
     
     /// A lazy loading text view that is especially useful for larger text files that should not be displayed all at once.
     /// - Parameter text: The text that should be displayed in the ``LazyText`` view.
     public init(text: LocalizedStringResource) {
-        self.text = text.localizedString()
+        self.text = text
     }
 }
 

--- a/Tests/UITests/TestApp/ViewsTests/NameFieldsTestView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/NameFieldsTestView.swift
@@ -12,6 +12,8 @@ import SwiftUI
 
 struct NameFieldsTestView: View {
     @State var name = PersonNameComponents()
+
+    @FocusState var focus: String?
     
     var body: some View {
         VStack {
@@ -22,7 +24,7 @@ struct NameFieldsTestView: View {
             )
                 .padding(32)
             Form {
-                NameFields(name: $name)
+                NameFields(name: $name, givenNameFieldIdentifier: "givenName", familyNameFieldIdentifier: "familyName", focusedState: $focus)
             }
         }
             .navigationBarTitleDisplayMode(.inline)

--- a/Tests/UITests/TestAppUITests/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/ViewsTests.swift
@@ -39,7 +39,7 @@ final class ViewsTests: XCTestCase {
         XCTAssert(app.buttons["Show Tool Picker"].waitForExistence(timeout: 2))
         app.buttons["Show Tool Picker"].tap()
         
-        sleep(2) // waitForExistence will otherwise return immediately
+        sleep(6) // waitForExistence will otherwise return immediately
         XCTAssertFalse(app.scrollViews.otherElements.images["palette_tool_pencil_base"].waitForExistence(timeout: 2))
         canvasView.swipeUp()
     }

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -8,16 +8,16 @@
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "NO"
+            buildForRunning = "YES"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "SpeziViews"
-               BuildableName = "SpeziViews"
-               BlueprintName = "SpeziViews"
-               ReferencedContainer = "container:../..">
+               BlueprintIdentifier = "2F6D139128F5F384007C25D6"
+               BuildableName = "TestApp.app"
+               BlueprintName = "TestApp"
+               ReferencedContainer = "container:UITests.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
@@ -76,6 +76,10 @@
             ReferencedContainer = "container:UITests.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <LocationScenarioReference
+         identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
+         referenceType = "1">
+      </LocationScenarioReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -14,10 +14,10 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "2F6D139128F5F384007C25D6"
-               BuildableName = "TestApp.app"
-               BlueprintName = "TestApp"
-               ReferencedContainer = "container:UITests.xcodeproj">
+               BlueprintIdentifier = "SpeziViews"
+               BuildableName = "SpeziViews"
+               BlueprintName = "SpeziViews"
+               ReferencedContainer = "container:../..">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry


### PR DESCRIPTION
<!--

This source file is part of the Stanford Spezi open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Allow for more customizable labels for DescriptionGridRow and NameFields, pass FocusState as Binding

## :recycle: Current situation & Problem
Currently, the `DescriptionGridRow` will force its `description` label to have `semibold` font weight. That might not be desirable in all circumstances.
Further, the `onTapFocus` modifier currently relies on a `FocusState` instance to be passed around instead of a `Binding` to such. While this seemingly doesn't make a lot of a difference it more clearly communicates the intend.

Those changes induced some modifications to the `NameFields` implementation. The PR made efforts to refactor common implementation of a single name row into a new `NameFieldRow` field.

## :gear: Release Notes 
* `DescriptionGridRow` allows for more customization by not forcing semibold font weight.
* `NameFields` allow for greater customization of the leading label view.
* `onTapFocus` modifier was updated to take a `FocusState.Binding`.
* `localizedString(_:)` method received a new optional argument to override the `Locale` before the String conversion. This is the recommended way to use within your SwiftUI views (by retrieved the current local from `@Environment(\.locale)`).

### Breaking Changes
* `DescriptionGridRow` doesn't render the description label as semibold.
* `NameFields` initializer change from taking a `FocusState` instance to taking a `FocusState.Binding` (change your code from `_focusState` to `$focusState`.

## :books: Documentation
Documentation was updated where necessary.


## :white_check_mark: Testing
Testing was not updated due to the non-functional nature of the changes.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
