### PR TITLE
Improve accessibility for Label view

### DIFF
--- a/Sources/SpeziViews/Views/Text/Label.swift
+++ b/Sources/SpeziViews/Views/Text/Label.swift
@@ -67,6 +67,9 @@ public struct Label: View {
                 preferredMaxLayoutWidth: width
             )
         }
+            .accessibilityRepresentation {
+                Text(text)
+            }
     }
     
     
@@ -113,3 +116,12 @@ public struct Label: View {
         self.numberOfLines = numberOfLines
     }
 }
+
+
+#if DEBUG
+struct Label_Previews: PreviewProvider {
+    static var previews: some View {
+        Label("This is very long text that wraps around multiple lines and adjusts the spacing between words accordingly.")
+    }
+}
+#endif

--- a/Tests/UITests/TestAppUITests/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/ViewsTests.swift
@@ -98,7 +98,7 @@ final class ViewsTests: XCTestCase {
         // The string value needs to be searched for in the UI.
         // swiftlint:disable:next line_length
         let text = "This is a label ... An other text. This is longer and we can check if the justified text works as expected. This is a very long text."
-        XCTAssertEqual(app.staticTexts.allElementsBoundByIndex.filter { $0.label.contains(text) }.count, 2)
+        XCTAssertEqual(app.staticTexts.allElementsBoundByIndex.filter { $0.label.replacingOccurrences(of: "\n", with: " ").contains(text) }.count, 2)
     }
     
     func testLazyText() throws {


### PR DESCRIPTION
<!--

This source file is part of the Stanford Spezi open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Improve accessibility for Label view

## :recycle: Current situation & Problem
Currently, the `Label` view is completely inaccessible as it relies on a `UIViewRepresentable`. This PR addresses this issue by creating a accessibility representation using the accessible, SwiftUI-native `Text` view.


## :gear: Release Notes 
* Improved accessibility of `Label` view.


## :books: Documentation
Nothing changed.


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
