### PR TITLE
View State Enhancements

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,7 +27,6 @@ jobs:
     name: Build and Test UI Tests
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
-      xcodeversion: latest
       artifactname: TestApp.xcresult
       runsonlabels: '["macOS", "self-hosted"]'
       path: 'Tests/UITests'

--- a/Sources/SpeziViews/Resources/de.lproj/Localizable.strings
+++ b/Sources/SpeziViews/Resources/de.lproj/Localizable.strings
@@ -17,6 +17,8 @@
 
 // MARK: MarkdownView
 "MARKDOWN_LOADING_ERROR" = "Das Dokument konnte nicht geladen werden.";
+"MARKDOWN_LOADING_ERROR_RECOVERY_SUGGESTION" = "Bitte prüfen Sie den Inhalt des Markdown Dokuments.";
+"MARKDOWN_LOADING_ERROR_FAILURE_REASON" = "Der Inhalt des Dokuments konnte nicht verarbeitet werden. Grund dessen ist ein invaliden Markdown Text.";
 
 // MARK: HTMLView
 "HTML_LOADING_ERROR" = "HTML konnte nicht geladen werden.";

--- a/Sources/SpeziViews/Resources/en.lproj/Localizable.strings
+++ b/Sources/SpeziViews/Resources/en.lproj/Localizable.strings
@@ -17,6 +17,8 @@
 
 // MARK: MarkdownView
 "MARKDOWN_LOADING_ERROR" = "Could not load and parse the document.";
+"MARKDOWN_LOADING_ERROR_RECOVERY_SUGGESTION" = "Please check the content of the markdown text.";
+"MARKDOWN_LOADING_ERROR_FAILURE_REASON" = "The system wasn't able to parse the given markdown text, indicating an invalid markdown text.";
 
 // MARK: HTMLView
 "HTML_LOADING_ERROR" = "Could not load the HTML.";

--- a/Sources/SpeziViews/Views/Text/DocumentView.swift
+++ b/Sources/SpeziViews/Views/Text/DocumentView.swift
@@ -37,12 +37,13 @@ public struct DocumentView: View {
 
     @Binding private var state: ViewState
 
+    
     public var documentView: AnyView {
         switch self.type {
         case .markdown:
-            return AnyView(MarkdownView(asyncMarkdown: asyncData))
+            return AnyView(MarkdownView(asyncMarkdown: asyncData, state: $state))
         case .html:
-            return AnyView(HTMLView(asyncHTML: asyncData))
+            return AnyView(HTMLView(asyncHTML: asyncData, state: $state))
         }
     }
 

--- a/Sources/SpeziViews/Views/Text/HTMLView.swift
+++ b/Sources/SpeziViews/Views/Text/HTMLView.swift
@@ -24,6 +24,38 @@ import WebKit
 /// )
 /// ```
 private struct WebView: UIViewRepresentable {
+    class Coordinator: NSObject, WKNavigationDelegate {
+        let parent: WebView
+        
+        @Binding private var state: ViewState
+        
+        
+        init(_ parent: WebView, state: Binding<ViewState>) {
+            self.parent = parent
+            self._state = state
+        }
+        
+        
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation) {
+            Task { @MainActor in
+                state = .idle
+            }
+        }
+        
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation, withError error: Error) {
+            Task { @MainActor in
+                state = .error(AnyLocalizedError(error: error))
+            }
+        }
+
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation, withError error: Error) {
+            Task { @MainActor in
+                state = .error(AnyLocalizedError(error: error))
+            }
+        }
+    }
+    
+    
     let htmlContent: String
     
     @Binding var state: ViewState
@@ -41,38 +73,6 @@ private struct WebView: UIViewRepresentable {
     
     func makeCoordinator() -> Coordinator {
         Coordinator(self, state: $state)
-    }
-    
-    
-    class Coordinator: NSObject, WKNavigationDelegate {
-        let parent: WebView
-        
-        @Binding private var state: ViewState
-        
-        
-        init(_ parent: WebView, state: Binding<ViewState>) {
-            self.parent = parent
-            self._state = state
-        }
-        
-        
-        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            Task { @MainActor in
-                state = .idle
-            }
-        }
-        
-        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-            Task { @MainActor in
-                state = .error(AnyLocalizedError(error: error))
-            }
-        }
-
-        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-            Task { @MainActor in
-                state = .error(AnyLocalizedError(error: error))
-            }
-        }
     }
 }
 

--- a/Sources/SpeziViews/Views/Text/HTMLView.swift
+++ b/Sources/SpeziViews/Views/Text/HTMLView.swift
@@ -24,15 +24,55 @@ import WebKit
 /// )
 /// ```
 private struct WebView: UIViewRepresentable {
-    var htmlContent: String
+    let htmlContent: String
+    
+    @Binding var state: ViewState
 
-
+    
     func makeUIView(context: Context) -> WKWebView {
-        WKWebView()
+        let webView = WKWebView()
+        webView.navigationDelegate = context.coordinator
+        return webView
     }
 
     func updateUIView(_ uiView: WKWebView, context: Context) {
         uiView.loadHTMLString(htmlContent, baseURL: nil)
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self, state: $state)
+    }
+    
+    
+    class Coordinator: NSObject, WKNavigationDelegate {
+        let parent: WebView
+        
+        @Binding private var state: ViewState
+        
+        
+        init(_ parent: WebView, state: Binding<ViewState>) {
+            self.parent = parent
+            self._state = state
+        }
+        
+        
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            Task { @MainActor in
+                state = .idle
+            }
+        }
+        
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+            Task { @MainActor in
+                state = .error(AnyLocalizedError(error: error))
+            }
+        }
+
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            Task { @MainActor in
+                state = .error(AnyLocalizedError(error: error))
+            }
+        }
     }
 }
 
@@ -58,11 +98,12 @@ public struct HTMLView: View {
                     .padding()
             } else {
                 if let htmlString {
-                    WebView(htmlContent: htmlString)
+                    WebView(htmlContent: htmlString, state: $state)
                 }
             }
         }
             .task {
+                state = .processing
                 html = await asyncHTML()
             }
     }
@@ -73,7 +114,7 @@ public struct HTMLView: View {
     ///   - state: A `Binding` to observe the ``ViewState`` of the ``HTMLView``.
     public init(
         asyncHTML: @escaping () async -> Data,
-        state: Binding<ViewState> = .constant(.idle)
+        state: Binding<ViewState> = .constant(.processing)
     ) {
         self.asyncHTML = asyncHTML
         self._state = state
@@ -85,7 +126,7 @@ public struct HTMLView: View {
     ///   - state: A `Binding` to observe the ``ViewState`` of the ``HTMLView``.
     public init(
         html: Data,
-        state: Binding<ViewState> = .constant(.idle)
+        state: Binding<ViewState> = .constant(.processing)
     ) {
         self.init(
             asyncHTML: { html },

--- a/Sources/SpeziViews/Views/Text/HTMLView.swift
+++ b/Sources/SpeziViews/Views/Text/HTMLView.swift
@@ -110,7 +110,7 @@ public struct HTMLView: View {
 
     /// Creates an ``HTMLView`` that displays HTML that is loaded asynchronously.
     /// - Parameters:
-    ///   - asyncHTML: The async closure to load the html as a utf8 representation.
+    ///   - asyncHTML: The async closure to load the html in an utf8 representation.
     ///   - state: A `Binding` to observe the ``ViewState`` of the ``HTMLView``.
     public init(
         asyncHTML: @escaping () async -> Data,
@@ -122,7 +122,7 @@ public struct HTMLView: View {
 
     /// Creates an ``HTMLView`` that displays the HTML content.
     /// - Parameters:
-    ///   - html: A `Data` instance containing the html as an utf8 representation.
+    ///   - html: A `Data` instance containing the html in an utf8 representation.
     ///   - state: A `Binding` to observe the ``ViewState`` of the ``HTMLView``.
     public init(
         html: Data,

--- a/Sources/SpeziViews/Views/Text/MarkdownView.swift
+++ b/Sources/SpeziViews/Views/Text/MarkdownView.swift
@@ -41,9 +41,6 @@ public struct MarkdownView: View {
                 markdown: markdown,
                 options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
               ) else {
-            Task { @MainActor in
-                state = .error(Error.markdownLoadingError)
-            }
             return AttributedString(
                 String(localized: "MARKDOWN_LOADING_ERROR", bundle: .module)
             )

--- a/Sources/SpeziViews/Views/Text/MarkdownView.swift
+++ b/Sources/SpeziViews/Views/Text/MarkdownView.swift
@@ -58,11 +58,9 @@ public struct MarkdownView: View {
             }
         }
             .task {
-                state = .processing
                 markdownString = parse(
                     markdown: await asyncMarkdown()
                 )
-                state = .idle
             }
     }
     
@@ -100,6 +98,8 @@ public struct MarkdownView: View {
     ///
     /// - Returns: Parsed Markdown as an `AttributedString`
     @MainActor private func parse(markdown: Data) -> AttributedString {
+        state = .processing
+        
         guard let markdownString = try? AttributedString(
                 markdown: markdown,
                 options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
@@ -110,6 +110,7 @@ public struct MarkdownView: View {
             )
         }
         
+        state = .idle
         return markdownString
     }
 }

--- a/Sources/SpeziViews/Views/Text/MarkdownView.swift
+++ b/Sources/SpeziViews/Views/Text/MarkdownView.swift
@@ -26,6 +26,18 @@ import SwiftUI
 public struct MarkdownView: View {
     public enum Error: LocalizedError {
         case markdownLoadingError
+        
+        public var errorDescription: String? {
+            "Failed to load the markdown text."
+        }
+        
+        public var recoverySuggestion: String? {
+            "Please check the content of the markdown text."
+        }
+
+        public var failureReason: String? {
+            "The system wasn't able to parse the given markdown text, indicating an invalid markdown text."
+        }
     }
     
     
@@ -41,10 +53,14 @@ public struct MarkdownView: View {
                 markdown: markdown,
                 options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
               ) else {
+            Task { @MainActor in
+                state = .error(Error.markdownLoadingError)
+            }
             return AttributedString(
                 String(localized: "MARKDOWN_LOADING_ERROR", bundle: .module)
             )
         }
+        
         Task { @MainActor in
             state = .idle
         }

--- a/Tests/UITests/TestApp/Localizable.xcstrings
+++ b/Tests/UITests/TestApp/Localizable.xcstrings
@@ -22,7 +22,11 @@
     "Hello Throwing World" : {
 
     },
+    "Hello World" : {
+
+    },
     "HELLO_WORLD" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/Tests/UITests/TestApp/Localizable.xcstrings
+++ b/Tests/UITests/TestApp/Localizable.xcstrings
@@ -22,11 +22,7 @@
     "Hello Throwing World" : {
 
     },
-    "Hello World" : {
-
-    },
     "HELLO_WORLD" : {
-      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/Tests/UITests/TestApp/ViewsTests/ViewStateTestView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/ViewStateTestView.swift
@@ -33,7 +33,7 @@ struct ViewStateTestView: View {
         Text("View State: \(String(describing: viewState))")
             .task {
                 viewState = .processing
-                try? await Task.sleep(for: .seconds(5))
+                try? await Task.sleep(for: .seconds(10))
                 viewState = .error(
                     AnyLocalizedError(
                         error: testError,

--- a/Tests/UITests/TestAppUITests/EnvironmentTests.swift
+++ b/Tests/UITests/TestAppUITests/EnvironmentTests.swift
@@ -15,9 +15,10 @@ final class EnvironmentTests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
 
+        XCTAssert(app.collectionViews.buttons["Default Error Description"].waitForExistence(timeout: 2))
         app.collectionViews.buttons["Default Error Description"].tap()
 
-        XCTAssert(app.staticTexts["View State: processing"].waitForExistence(timeout: 1))
+        XCTAssert(app.staticTexts["View State: processing"].waitForExistence(timeout: 2))
 
         sleep(6)
 
@@ -26,6 +27,7 @@ final class EnvironmentTests: XCTestCase {
         XCTAssert(alert.staticTexts["Failure Reason\n\nHelp Anchor\n\nRecovery Suggestion"].exists)
         alert.buttons["OK"].tap()
 
+        XCTAssert(app.staticTexts["View State: idle"].waitForExistence(timeout: 2))
         app.staticTexts["View State: idle"].tap()
     }
 }

--- a/Tests/UITests/TestAppUITests/EnvironmentTests.swift
+++ b/Tests/UITests/TestAppUITests/EnvironmentTests.swift
@@ -20,7 +20,7 @@ final class EnvironmentTests: XCTestCase {
 
         XCTAssert(app.staticTexts["View State: processing"].waitForExistence(timeout: 2))
 
-        sleep(6)
+        sleep(12)
 
         let alert = app.alerts.firstMatch.scrollViews.otherElements
         XCTAssert(alert.staticTexts["This is a default error description!"].exists)

--- a/Tests/UITests/TestAppUITests/ModelTests.swift
+++ b/Tests/UITests/TestAppUITests/ModelTests.swift
@@ -40,7 +40,7 @@ final class ModelTests: XCTestCase {
 
         XCTAssert(app.staticTexts["View State: processing"].waitForExistence(timeout: 2))
 
-        sleep(6)
+        sleep(12)
 
         let alert = app.alerts.firstMatch.scrollViews.otherElements
         XCTAssert(alert.staticTexts["Error"].exists)

--- a/Tests/UITests/TestAppUITests/ModelTests.swift
+++ b/Tests/UITests/TestAppUITests/ModelTests.swift
@@ -15,9 +15,10 @@ final class ModelTests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
 
+        XCTAssert(app.collectionViews.buttons["View State"].waitForExistence(timeout: 2))
         app.collectionViews.buttons["View State"].tap()
 
-        XCTAssert(app.staticTexts["View State: processing"].waitForExistence(timeout: 1))
+        XCTAssert(app.staticTexts["View State: processing"].waitForExistence(timeout: 2))
 
         sleep(6)
 
@@ -26,6 +27,7 @@ final class ModelTests: XCTestCase {
         XCTAssert(alert.staticTexts["Failure Reason\n\nHelp Anchor\n\nRecovery Suggestion"].exists)
         alert.buttons["OK"].tap()
 
+        XCTAssert(app.staticTexts["View State: idle"].waitForExistence(timeout: 2))
         app.staticTexts["View State: idle"].tap()
     }
 
@@ -33,9 +35,10 @@ final class ModelTests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
 
+        XCTAssert(app.collectionViews.buttons["Default Error Only"].waitForExistence(timeout: 2))
         app.collectionViews.buttons["Default Error Only"].tap()
 
-        XCTAssert(app.staticTexts["View State: processing"].waitForExistence(timeout: 1))
+        XCTAssert(app.staticTexts["View State: processing"].waitForExistence(timeout: 2))
 
         sleep(6)
 
@@ -44,6 +47,7 @@ final class ModelTests: XCTestCase {
         XCTAssert(alert.staticTexts["Some error occurred!"].exists)
         alert.buttons["OK"].tap()
 
+        XCTAssert(app.staticTexts["View State: idle"].waitForExistence(timeout: 2))
         app.staticTexts["View State: idle"].tap()
     }
 }

--- a/Tests/UITests/TestAppUITests/ModelTests.swift
+++ b/Tests/UITests/TestAppUITests/ModelTests.swift
@@ -20,7 +20,7 @@ final class ModelTests: XCTestCase {
 
         XCTAssert(app.staticTexts["View State: processing"].waitForExistence(timeout: 2))
 
-        sleep(6)
+        sleep(12)
 
         let alert = app.alerts.firstMatch.scrollViews.otherElements
         XCTAssert(alert.staticTexts["Error Description"].exists)

--- a/Tests/UITests/TestAppUITests/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/ViewsTests.swift
@@ -140,8 +140,8 @@ final class ViewsTests: XCTestCase {
         XCTAssert(app.collectionViews.buttons["HTML View"].waitForExistence(timeout: 2))
         app.collectionViews.buttons["HTML View"].tap()
         
-        XCTAssert(app.webViews.staticTexts["This is an HTML example."].waitForExistence(timeout: 15))
-        XCTAssert(app.staticTexts["This is an HTML example taking 5 seconds to load."].waitForExistence(timeout: 10))
+        XCTAssert(app.webViews.staticTexts["This is an HTML example."].waitForExistence(timeout: 30))
+        XCTAssert(app.staticTexts["This is an HTML example taking 5 seconds to load."].waitForExistence(timeout: 20))
     }
 
     func testAsyncButtonView() throws {

--- a/Tests/UITests/TestAppUITests/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/ViewsTests.swift
@@ -19,6 +19,7 @@ final class ViewsTests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
         
+        XCTAssert(app.collectionViews.buttons["Canvas"].waitForExistence(timeout: 2))
         app.collectionViews.buttons["Canvas"].tap()
         
         XCTAssert(app.staticTexts["Did Draw Anything: false"].waitForExistence(timeout: 5))
@@ -48,12 +49,13 @@ final class ViewsTests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
         
+        XCTAssert(app.collectionViews.buttons["Name Fields"].waitForExistence(timeout: 2))
         app.collectionViews.buttons["Name Fields"].tap()
         
-        XCTAssert(app.staticTexts["First Title"].waitForExistence(timeout: 1))
-        XCTAssert(app.staticTexts["Second Title"].exists)
-        XCTAssert(app.staticTexts["First Name"].exists)
-        XCTAssert(app.staticTexts["Last Name"].exists)
+        XCTAssert(app.staticTexts["First Title"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Second Title"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["First Name"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Last Name"].waitForExistence(timeout: 2))
         
         try app.textFields["First Placeholder"].enter(value: "Le")
         try app.textFields["Second Placeholder"].enter(value: "Stan")
@@ -61,26 +63,28 @@ final class ViewsTests: XCTestCase {
         try app.textFields["Enter your first name ..."].enter(value: "land")
         try app.textFields["Enter your last name ..."].enter(value: "ford")
         
-        XCTAssert(app.textFields["Leland"].exists)
-        XCTAssert(app.textFields["Stanford"].exists)
+        XCTAssert(app.textFields["Leland"].waitForExistence(timeout: 2))
+        XCTAssert(app.textFields["Stanford"].waitForExistence(timeout: 2))
     }
     
     func testUserProfile() throws {
         let app = XCUIApplication()
         app.launch()
         
+        XCTAssert(app.collectionViews.buttons["User Profile"].waitForExistence(timeout: 2))
         app.collectionViews.buttons["User Profile"].tap()
         
-        XCTAssertTrue(app.staticTexts["PS"].waitForExistence(timeout: 1))
+        XCTAssertTrue(app.staticTexts["PS"].waitForExistence(timeout: 2))
         XCTAssertTrue(app.staticTexts["LS"].exists)
         
-        XCTAssertTrue(app.images["person.crop.artframe"].waitForExistence(timeout: 3.5))
+        XCTAssertTrue(app.images["person.crop.artframe"].waitForExistence(timeout: 5))
     }
     
     func testGeometryReader() throws {
         let app = XCUIApplication()
         app.launch()
         
+        XCTAssert(app.collectionViews.buttons["Geometry Reader"].waitForExistence(timeout: 2))
         app.collectionViews.buttons["Geometry Reader"].tap()
         
         XCTAssert(app.staticTexts["300.000000"].exists)
@@ -91,6 +95,7 @@ final class ViewsTests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
         
+        XCTAssert(app.collectionViews.buttons["Label"].waitForExistence(timeout: 2))
         app.collectionViews.buttons["Label"].tap()
 
         sleep(2)
@@ -105,9 +110,10 @@ final class ViewsTests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
         
+        XCTAssert(app.collectionViews.buttons["Lazy Text"].waitForExistence(timeout: 2))
         app.collectionViews.buttons["Lazy Text"].tap()
         
-        XCTAssert(app.staticTexts["This is a long text ..."].waitForExistence(timeout: 1))
+        XCTAssert(app.staticTexts["This is a long text ..."].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["And some more lines ..."].exists)
         XCTAssert(app.staticTexts["And a third line ..."].exists)
         XCTAssert(app.staticTexts["An other lazy text ..."].exists)
@@ -117,9 +123,10 @@ final class ViewsTests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
         
+        XCTAssert(app.collectionViews.buttons["Markdown View"].waitForExistence(timeout: 2))
         app.collectionViews.buttons["Markdown View"].tap()
         
-        XCTAssert(app.staticTexts["This is a markdown example."].waitForExistence(timeout: 1))
+        XCTAssert(app.staticTexts["This is a markdown example."].waitForExistence(timeout: 2))
 
         sleep(6)
         
@@ -130,6 +137,7 @@ final class ViewsTests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
         
+        XCTAssert(app.collectionViews.buttons["HTML View"].waitForExistence(timeout: 2))
         app.collectionViews.buttons["HTML View"].tap()
         
         XCTAssert(app.webViews.staticTexts["This is an HTML example."].waitForExistence(timeout: 15))
@@ -140,9 +148,10 @@ final class ViewsTests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
 
+        XCTAssert(app.collectionViews.buttons["Async Button"].waitForExistence(timeout: 2))
         app.collectionViews.buttons["Async Button"].tap()
 
-        XCTAssert(app.collectionViews.buttons["Hello World"].waitForExistence(timeout: 1))
+        XCTAssert(app.collectionViews.buttons["Hello World"].waitForExistence(timeout: 2))
         app.collectionViews.buttons["Hello World"].tap()
 
         XCTAssert(app.collectionViews.staticTexts["Action executed"].waitForExistence(timeout: 2))

--- a/Tests/UITests/TestAppUITests/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/ViewsTests.swift
@@ -21,8 +21,8 @@ final class ViewsTests: XCTestCase {
         
         app.collectionViews.buttons["Canvas"].tap()
         
-        XCTAssert(app.staticTexts["Did Draw Anything: false"].waitForExistence(timeout: 2))
-        XCTAssertFalse(app.scrollViews.otherElements.images["palette_tool_pencil_base"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Did Draw Anything: false"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.scrollViews.otherElements.images["palette_tool_pencil_base"].waitForExistence(timeout: 5))
         
         let canvasView = app.scrollViews.firstMatch
         canvasView.swipeRight()
@@ -33,14 +33,14 @@ final class ViewsTests: XCTestCase {
         XCTAssert(app.buttons["Show Tool Picker"].waitForExistence(timeout: 2))
         app.buttons["Show Tool Picker"].tap()
         
-        XCTAssert(app.scrollViews.otherElements.images["palette_tool_pencil_base"].waitForExistence(timeout: 2))
+        XCTAssert(app.scrollViews.otherElements.images["palette_tool_pencil_base"].waitForExistence(timeout: 5))
         canvasView.swipeLeft()
         
         XCTAssert(app.buttons["Show Tool Picker"].waitForExistence(timeout: 2))
         app.buttons["Show Tool Picker"].tap()
         
-        sleep(6) // waitForExistence will otherwise return immediately
-        XCTAssertFalse(app.scrollViews.otherElements.images["palette_tool_pencil_base"].waitForExistence(timeout: 2))
+        sleep(10) // waitForExistence will otherwise return immediately
+        XCTAssertFalse(app.scrollViews.otherElements.images["palette_tool_pencil_base"].waitForExistence(timeout: 5))
         canvasView.swipeUp()
     }
     

--- a/Tests/UITests/TestAppUITests/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/ViewsTests.swift
@@ -22,26 +22,25 @@ final class ViewsTests: XCTestCase {
         XCTAssert(app.collectionViews.buttons["Canvas"].waitForExistence(timeout: 2))
         app.collectionViews.buttons["Canvas"].tap()
         
-        XCTAssert(app.staticTexts["Did Draw Anything: false"].waitForExistence(timeout: 5))
-        XCTAssertFalse(app.scrollViews.otherElements.images["palette_tool_pencil_base"].waitForExistence(timeout: 5))
+        XCTAssert(app.staticTexts["Did Draw Anything: false"].waitForExistence(timeout: 2))
+        XCTAssertFalse(app.scrollViews.otherElements.images["palette_tool_pencil_base"].waitForExistence(timeout: 2))
         
         let canvasView = app.scrollViews.firstMatch
         canvasView.swipeRight()
         canvasView.swipeDown()
         
-        XCTAssert(app.staticTexts["Did Draw Anything: true"].exists)
+        XCTAssert(app.staticTexts["Did Draw Anything: true"].waitForExistence(timeout: 2))
         
         XCTAssert(app.buttons["Show Tool Picker"].waitForExistence(timeout: 2))
         app.buttons["Show Tool Picker"].tap()
         
-        XCTAssert(app.scrollViews.otherElements.images["palette_tool_pencil_base"].waitForExistence(timeout: 5))
+        XCTAssert(app.scrollViews.otherElements.images["palette_tool_pencil_base"].waitForExistence(timeout: 10))
         canvasView.swipeLeft()
         
-        XCTAssert(app.buttons["Show Tool Picker"].waitForExistence(timeout: 2))
         app.buttons["Show Tool Picker"].tap()
         
-        sleep(10) // waitForExistence will otherwise return immediately
-        XCTAssertFalse(app.scrollViews.otherElements.images["palette_tool_pencil_base"].waitForExistence(timeout: 5))
+        sleep(15) // waitForExistence will otherwise return immediately
+        XCTAssertFalse(app.scrollViews.otherElements.images["palette_tool_pencil_base"].waitForExistence(timeout: 10))
         canvasView.swipeUp()
     }
     

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -184,7 +184,7 @@
 			);
 			name = TestAppUITests;
 			packageProductDependencies = (
-				977CF55E2AD2B92C006D9B54 /* XCTestExtensions */,
+				977CF55D2AD2B92C006D9B54 /* XCTestExtensions */,
 			);
 			productName = ExampleUITests;
 			productReference = 2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */;

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -184,7 +184,7 @@
 			);
 			name = TestAppUITests;
 			packageProductDependencies = (
-				977CF55A2AD2B92C006D9B54 /* XCTestExtensions */,
+				977CF55E2AD2B92C006D9B54 /* XCTestExtensions */,
 			);
 			productName = ExampleUITests;
 			productReference = 2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */;

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -18,9 +18,9 @@
 		2FA9486B29DE90720081C086 /* HTMLViewTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA9486429DE90720081C086 /* HTMLViewTestView.swift */; };
 		2FA9486D29DE91130081C086 /* ViewsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA9486C29DE91130081C086 /* ViewsTests.swift */; };
 		2FA9486F29DE91A30081C086 /* SpeziViews in Frameworks */ = {isa = PBXBuildFile; productRef = 2FA9486E29DE91A30081C086 /* SpeziViews */; };
-		2FA9487129DE91CC0081C086 /* XCTestApp in Frameworks */ = {isa = PBXBuildFile; productRef = 2FA9487029DE91CC0081C086 /* XCTestApp */; };
-		2FA9487329DE92410081C086 /* XCTestExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 2FA9487229DE92410081C086 /* XCTestExtensions */; };
 		2FB099B82A8AD25300B20952 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 2FB099B72A8AD25100B20952 /* Localizable.xcstrings */; };
+		977CF55C2AD2B92C006D9B54 /* XCTestApp in Frameworks */ = {isa = PBXBuildFile; productRef = 977CF55B2AD2B92C006D9B54 /* XCTestApp */; };
+		977CF55E2AD2B92C006D9B54 /* XCTestExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 977CF55D2AD2B92C006D9B54 /* XCTestExtensions */; };
 		A97880972A4C4E6500150B2F /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97880962A4C4E6500150B2F /* ModelTests.swift */; };
 		A97880992A4C524D00150B2F /* DefaultErrorDescriptionTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97880982A4C524D00150B2F /* DefaultErrorDescriptionTestView.swift */; };
 		A978809B2A4C52F100150B2F /* EnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A978809A2A4C52F100150B2F /* EnvironmentTests.swift */; };
@@ -65,7 +65,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2FA9486F29DE91A30081C086 /* SpeziViews in Frameworks */,
-				2FA9487129DE91CC0081C086 /* XCTestApp in Frameworks */,
+				977CF55C2AD2B92C006D9B54 /* XCTestApp in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -73,7 +73,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2FA9487329DE92410081C086 /* XCTestExtensions in Frameworks */,
+				977CF55C2AD2B92C006D9B54 /* XCTestExtensions in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -163,7 +163,7 @@
 			name = TestApp;
 			packageProductDependencies = (
 				2FA9486E29DE91A30081C086 /* SpeziViews */,
-				2FA9487029DE91CC0081C086 /* XCTestApp */,
+				977CF55B2AD2B92C006D9B54 /* XCTestApp */,
 			);
 			productName = Example;
 			productReference = 2F6D139228F5F384007C25D6 /* TestApp.app */;
@@ -184,7 +184,7 @@
 			);
 			name = TestAppUITests;
 			packageProductDependencies = (
-				2FA9487229DE92410081C086 /* XCTestExtensions */,
+				977CF55A2AD2B92C006D9B54 /* XCTestExtensions */,
 			);
 			productName = ExampleUITests;
 			productReference = 2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */;
@@ -220,7 +220,7 @@
 			);
 			mainGroup = 2F6D138928F5F384007C25D6;
 			packageReferences = (
-				2F2D337F29DE4A6000081B1D /* XCRemoteSwiftPackageReference "XCTestExtensions" */,
+				977CF55A2AD2B92C006D9B54 /* XCRemoteSwiftPackageReference "XCTestExtensions" */,
 			);
 			productRefGroup = 2F6D139328F5F384007C25D6 /* Products */;
 			projectDirPath = "";
@@ -655,12 +655,12 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		2F2D337F29DE4A6000081B1D /* XCRemoteSwiftPackageReference "XCTestExtensions" */ = {
+		977CF55A2AD2B92C006D9B54 /* XCRemoteSwiftPackageReference "XCTestExtensions" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/StanfordSpezi/XCTestExtensions.git";
+			repositoryURL = "https://github.com/StanfordBDHG/XCTestExtensions";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.6;
+				minimumVersion = 0.4.7;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -670,14 +670,14 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = SpeziViews;
 		};
-		2FA9487029DE91CC0081C086 /* XCTestApp */ = {
+		977CF55B2AD2B92C006D9B54 /* XCTestApp */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 2F2D337F29DE4A6000081B1D /* XCRemoteSwiftPackageReference "XCTestExtensions" */;
+			package = 977CF55A2AD2B92C006D9B54 /* XCRemoteSwiftPackageReference "XCTestExtensions" */;
 			productName = XCTestApp;
 		};
-		2FA9487229DE92410081C086 /* XCTestExtensions */ = {
+		977CF55D2AD2B92C006D9B54 /* XCTestExtensions */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 2F2D337F29DE4A6000081B1D /* XCRemoteSwiftPackageReference "XCTestExtensions" */;
+			package = 977CF55A2AD2B92C006D9B54 /* XCRemoteSwiftPackageReference "XCTestExtensions" */;
 			productName = XCTestExtensions;
 		};
 /* End XCSwiftPackageProductDependency section */


### PR DESCRIPTION
<!--

This source file is part of the Stanford Spezi open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# *View State Enhancements*

## :recycle: Current situation & Problem
At the moment, `ViewState`s are designed to be used throughout the `SpeziViews` architecture, however, the actual utilization of those `ViewState`s is quite limited. This is especially true for `MarkdownView` and `HTMLView` views, as they have the architecture to handle `ViewState`s, but they aren't used for now (see StanfordSpezi/SpeziOnboarding#26).

## :gear: Release Notes 
- `MarkdownView` and `HTMLView` views now include proper `ViewState` handling, including processing, idle and error states.


## :books: Documentation
--


## :white_check_mark: Testing
Test cases have been adjusted.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
