### PR TITLE
Add PersonalInfo and Validation to SPI documentation targets

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -11,4 +11,6 @@ builder:
   configs:
     - platform: ios
       documentation_targets:
-      - SpeziViews
+        - SpeziViews
+        - SpeziPersonalInfo
+        - SpeziValidation

--- a/.spi.yml
+++ b/.spi.yml
@@ -6,6 +6,7 @@
 # SPDX-License-Identifier: MIT
 # 
 
+
 version: 1
 builder:
   configs:


### PR DESCRIPTION
# Add PersonalInfo and Validation to SPI documentation targets

## :recycle: Current situation & Problem
#20  and #21 introduced additional documentation targets. This PR adds them to the spi.yml such that the Swift Package Index properly builds them.


## :gear: Release Notes 
* Configured new documentation targets to be exported to SPI.


## :books: Documentation
--


## :white_check_mark: Testing
--

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
