### PR TITLE
Fix accessibility for ListRow

### DIFF
--- a/Sources/SpeziViews/Views/List/ListRow.swift
+++ b/Sources/SpeziViews/Views/List/ListRow.swift
@@ -61,6 +61,7 @@ public struct ListRow<Label: View, Content: View>: View {
                 Spacer()
             }
         }
+            .accessibilityElement(children: .combine)
             .onPreferenceChange(DynamicLayout.self) { value in
                 layout = value
             }

--- a/Tests/UITests/TestApp/ViewsTests/SpeziViewsTests.swift
+++ b/Tests/UITests/TestApp/ViewsTests/SpeziViewsTests.swift
@@ -23,6 +23,7 @@ enum SpeziViewsTests: String, TestAppTests {
     case defaultErrorOnly = "Default Error Only"
     case defaultErrorDescription = "Default Error Description"
     case asyncButton = "Async Button"
+    case listRow = "List Row"
     
     
     @ViewBuilder
@@ -104,7 +105,15 @@ enum SpeziViewsTests: String, TestAppTests {
     private var asyncButton: some View {
         AsyncButtonTestView()
     }
-    
+
+    @ViewBuilder
+    private var listRow: some View {
+        List {
+            ListRow(verbatim: "Hello") {
+                Text(verbatim: "World")
+            }
+        }
+    }
 
     func view(withNavigationPath path: Binding<NavigationPath>) -> some View {  // swiftlint:disable:this cyclomatic_complexity
         switch self {
@@ -130,6 +139,8 @@ enum SpeziViewsTests: String, TestAppTests {
             defaultErrorDescription
         case .asyncButton:
             asyncButton
+        case .listRow:
+            listRow
         }
     }
 }

--- a/Tests/UITests/TestApp/ViewsTests/SpeziViewsTests.swift
+++ b/Tests/UITests/TestApp/ViewsTests/SpeziViewsTests.swift
@@ -106,6 +106,7 @@ enum SpeziViewsTests: String, TestAppTests {
         AsyncButtonTestView()
     }
 
+    @MainActor
     @ViewBuilder
     private var listRow: some View {
         List {

--- a/Tests/UITests/TestAppUITests/SpeziViews/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/SpeziViews/ViewsTests.swift
@@ -126,4 +126,13 @@ final class ViewsTests: XCTestCase {
 
         XCTAssert(app.collectionViews.buttons["Hello Throwing World"].isEnabled)
     }
+
+    func testListRowAccessibility() throws {
+        let app = XCUIApplication()
+
+        XCTAssert(app.collectionViews.buttons["List Row"].waitForExistence(timeout: 2))
+        app.collectionViews.buttons["List Row"].tap()
+
+        XCTAssert(app.collectionViews.staticTexts["Hello, World"].waitForExistence(timeout: 2))
+    }
 }


### PR DESCRIPTION
# Fix accessibility for ListRow

## :recycle: Current situation & Problem
We have a great capability to make `ListRow` more accessible out of the box. This PR adds this small modifier and adds respective unit tests.


## :gear: Release Notes 
* Make ListRow more accessible


## :books: Documentation
--


## :white_check_mark: Testing
Added unit testing to test this behavior.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
