### PR TITLE
Add SwiftUI `Binding` Negation

### DIFF
--- a/Sources/SpeziViews/Utilities/Binding+Negate.swift
+++ b/Sources/SpeziViews/Utilities/Binding+Negate.swift
@@ -1,0 +1,20 @@
+//
+// This source file is part of the Stanford Spezi project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+
+extension Binding where Value == Bool {
+    /// Negates a `Binding`.
+    public prefix static func ! (value: Binding<Bool>) -> Binding<Bool> {
+        Binding<Bool>(
+            get: { !value.wrappedValue },
+            set: { value.wrappedValue = !$0 }
+        )
+    }
+}

--- a/Sources/SpeziViews/Utilities/Binding+Negate.swift
+++ b/Sources/SpeziViews/Utilities/Binding+Negate.swift
@@ -10,7 +10,38 @@ import SwiftUI
 
 
 extension Binding where Value == Bool {
-    /// Negates a `Binding`.
+    /// Negates a SwiftUI `Binding`.
+    ///
+    /// ### Usage
+    ///
+    /// The example below demonstrates a minimal use case of a negated SwiftUI `Binding` by toggling a shared boolean state in different `View`s.
+    ///
+    /// ```swift
+    /// struct ParentView: View {
+    ///     @State var isOn: Bool = false
+    ///
+    ///     var body: some View {
+    ///         VStack {
+    ///             Button(isOn ? "Turn Off" : "Turn On") {
+    ///                 isOn.toggle()
+    ///             }
+    ///
+    ///             // Pass an inverted `Binding` to the `ChildView`.
+    ///             ChildView(isOff: !$isOn)
+    ///         }
+    ///    }
+    /// }
+    ///
+    /// struct ChildView: View {
+    ///     @Binding var isOff: Bool
+    ///
+    ///     var body: some View {
+    ///         Button("Toggle from Child View") {
+    ///             isOff.toggle()
+    ///         }
+    ///     }
+    /// }
+    /// ```
     public prefix static func ! (value: Binding<Bool>) -> Binding<Bool> {
         Binding<Bool>(
             get: { !value.wrappedValue },


### PR DESCRIPTION
# Add SwiftUI `Binding` Negation

## :recycle: Current situation & Problem
We currently use the negation of a SwiftUI `Binding` in lots of different Spezi modules. 
Each module needs to define the `Binding` extension on their own.


## :gear: Release Notes 
- Adds a SwiftUI `Binding` Negation


## :books: Documentation
Proper documentation of added code


## :white_check_mark: Testing
No test cases added


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
