### PR TITLE
Implemented small change to markdown formatting, and added docs

### DIFF
--- a/Sources/SpeziViews/Views/Text/MarkdownView.swift
+++ b/Sources/SpeziViews/Views/Text/MarkdownView.swift
@@ -96,16 +96,18 @@ public struct MarkdownView: View {
     /// Parses the incoming markdown and handles the view's error state management.
     /// - Parameters:
     ///   - markdown: A `Data` instance containing the markdown file in an utf8 representation.
-    ///   Example: Data(
-    ///   " # This is a markdown example
+    ///   ```swift
+    ///   // Example
+    ///   Data(" # This is a markdown example
     ///    *This should be italiced* and **this bolded**").utf8
+    ///    ```
     /// - Returns: Parsed Markdown as an `AttributedString`
     @MainActor private func parse(markdown: Data) -> AttributedString {
         state = .processing
         
         guard let markdownString = try? AttributedString(
                 markdown: markdown,
-                options: .init(interpretedSyntax: .full)
+                options: .init(interpretedSyntax: .inlineOnly)
               ) else {
             state = .error(Error.markdownLoadingError)
             return AttributedString(

--- a/Sources/SpeziViews/Views/Text/MarkdownView.swift
+++ b/Sources/SpeziViews/Views/Text/MarkdownView.swift
@@ -66,6 +66,7 @@ public struct MarkdownView: View {
     
     
     /// Creates a ``MarkdownView`` that displays the content of a markdown file as an utf8 representation that is loaded asynchronously.
+
     /// - Parameters:
     ///   - asyncMarkdown: An async closure to load the markdown in an utf8 representation.
     ///   - state: A `Binding` to observe the ``ViewState`` of the ``MarkdownView``.
@@ -95,14 +96,16 @@ public struct MarkdownView: View {
     /// Parses the incoming markdown and handles the view's error state management.
     /// - Parameters:
     ///   - markdown: A `Data` instance containing the markdown file in an utf8 representation.
-    ///
+    ///   Example: Data(
+    ///   " # This is a markdown example
+    ///    *This should be italiced* and **this bolded**").utf8
     /// - Returns: Parsed Markdown as an `AttributedString`
     @MainActor private func parse(markdown: Data) -> AttributedString {
         state = .processing
         
         guard let markdownString = try? AttributedString(
                 markdown: markdown,
-                options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+                options: .init(interpretedSyntax: .full)
               ) else {
             state = .error(Error.markdownLoadingError)
             return AttributedString(

--- a/Sources/SpeziViews/Views/Text/TextContent.swift
+++ b/Sources/SpeziViews/Views/Text/TextContent.swift
@@ -8,11 +8,24 @@
 
 import Foundation
 
-
+/// The `TextContent` enum represents either a plain string or a localized string resource.
+///
+/// Use this enum to encapsulate text content in your application, allowing flexibility in handling localized and non-localized strings.
+///
+/// ```swift
+/// // Example usage:
+/// let content: TextContent = .localized(LocalizedStringResource("HELLO_SPEZI", bundle: .main))
+/// let localizedString = content.localizedString(for: .current)
+/// print(localizedString) // Prints the localized string for the current locale.
+/// ```
 enum TextContent {
     case string(_ value: String)
     case localized(_ value: LocalizedStringResource)
 
+    /// Returns the localized string representation of the content for a given locale.
+    ///
+    /// - Parameter locale: The locale for which to retrieve the localized string.
+    /// - Returns: The localized string corresponding to the content.
     func localizedString(for locale: Locale) -> String {
         switch self {
         case let .string(string):


### PR DESCRIPTION
# *Markdown formatting + documentation*

## :recycle: Current situation & Problem
The current SpeziViews module were not all well documented equally, as per the documentation requirements set forth in the [Stanford Spezi Documentation Guide.](https://swiftpackageindex.com/stanfordspezi/spezi/1.2.1/documentation/spezi/documentation-guide#Landing-Page). Also, the markdown formatting was restricted to `inlineOnly` changes, which would not render formatting for larger changes like titles, which was the issue our app's consent doc ran into.


## :gear: Release Notes 
- Changed markdown formatting to `.full` to incorporate the full breadth of document markdowns
- Added documentation for the Localizable strings section in text


## :books: Documentation
- Added documentation is line with the [Spezi Documentation Guide](https://swiftpackageindex.com/stanfordspezi/spezi/1.2.1/documentation/spezi/documentation-guide#Landing-Page)


## :white_check_mark: Testing
- For the markdown formatting, used the `AttributedString` framework to render markdown documents locally, and it seemed to render properly. Not sure what edge cases the Spezi team wanted to account for by setting it to `inline`, so further testing for the full template application is needed.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
