### PR TITLE
Logger infrastructure for SwiftUI

### DIFF
--- a/Sources/SpeziViews/Environment/Logger.swift
+++ b/Sources/SpeziViews/Environment/Logger.swift
@@ -1,0 +1,31 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import OSLog
+import SwiftUI
+
+/// An `EnvironmentKey` to be used for providing a specific `Logger` object to subviews.
+///
+/// This might be useful to provide a logger to generic subviews depending on the context they are being used in.
+private struct LoggerKey: EnvironmentKey {
+    static let defaultValue: Logger = .init()
+}
+
+extension EnvironmentValues {
+    /// A `Logger` to be used when logging capabilities are required.
+    ///
+    /// This might be useful to provide a logger to generic subviews depending on the context they are being used in.
+    public var logger: Logger {
+        get {
+            self[LoggerKey.self]
+        }
+        set {
+            self[LoggerKey.self] = newValue
+        }
+    }
+}


### PR DESCRIPTION
# Logger infrastructure for SwiftUI

## :recycle: Current situation & Problem
Fixes #9 by allowing the injection of Loggers into the SwiftUI environment. It doesn't (yet) make use of them, since I'm not sure on the desired granularity level of the subsystem and category values.


## :gear: Release Notes 
- Allows the injection of Logger instances into subviews to more easily define subview's logging behavior, especially for generic views.


## :books: Documentation
- Adds documentation for LoggerKey (even though it is private). I noticed that the other environment keys are internal, is there a specific reason for them not to be private?

## :white_check_mark: Testing
No testing code provided.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
