### PR TITLE
Docs: Add ViewState Documentation

### DIFF
--- a/Sources/SpeziViews/Model/ViewState.swift
+++ b/Sources/SpeziViews/Model/ViewState.swift
@@ -14,6 +14,18 @@ import Foundation
 /// A `ViewState` provides a built-in mechanism for tracking the state of a Spezi UI component.
 /// A view can be in either an `idle`, `processing`, or `error` `ViewState`.
 ///
+/// The ``SwiftUI/View/viewStateAlert(state:)-4wzs4`` view modifier can be used to automatically notify users with an
+/// [`Alert`](https://developer.apple.com/documentation/swiftui/view/alert(_:ispresented:actions:)-3npin) when the
+/// `ViewState` enters an error state.
+///
+/// This is why the `error` state takes a
+/// [`LocalizedError`](https://developer.apple.com/documentation/foundation/localizederror) as an associated value;
+/// it provides a localized error description for the alert that is presented to users.
+///
+/// > Tip:
+/// > Use ``AnyLocalizedError`` for handling localized and non-localized errors at the same time. Non-localized
+/// > errors are handled on a best-effort basis, meaning that not always a description for them may be available.
+///
 /// ```swift
 /// import SpeziViews
 /// import SwiftUI
@@ -46,10 +58,6 @@ import Foundation
 ///     }
 /// }
 /// ```
-///
-/// The ``SwiftUI/View/viewStateAlert(state:)-4wzs4`` view modifier can be used to automatically notify users with an
-/// [`Alert`](https://developer.apple.com/documentation/swiftui/view/alert(_:ispresented:actions:)-3npin) when the
-/// `ViewState` enters an error state.
 ///
 /// > Tip:
 /// > To avoid having to handle state changes manually (as seen above), a `ViewState` can be mapped to an

--- a/Sources/SpeziViews/Model/ViewState.swift
+++ b/Sources/SpeziViews/Model/ViewState.swift
@@ -37,10 +37,8 @@ import Foundation
 ///                 do {
 ///                     try doSomeProcessing()
 ///                     viewState = .idle
-///                 } catch let error as LocalizedError {
-///                     viewState = .error(error)
 ///                 } catch {
-///                     print("An unknown error occurred: \(error)")
+///                     viewState = .error(AnyLocalizedError(error: error))
 ///                 }
 ///             }
 ///             .viewStateAlert(state: $viewState)

--- a/Sources/SpeziViews/Model/ViewState.swift
+++ b/Sources/SpeziViews/Model/ViewState.swift
@@ -9,22 +9,22 @@
 import Foundation
 
 
-/// Allows SwiftUI views to keep track of their state and communicate to outside views.
+/// Allows SwiftUI views to track their state and communicate with other views.
 ///
 /// A `ViewState` provides a built-in mechanism for tracking the state of a Spezi UI component.
-/// A view can be in either an `idle`, `processing`, or `error` `ViewState`.
+/// A view can be in one of three states: `idle`, `processing`, or `error`.
 ///
 /// The ``SwiftUI/View/viewStateAlert(state:)-4wzs4`` view modifier can be used to automatically notify users with an
 /// [`Alert`](https://developer.apple.com/documentation/swiftui/view/alert(_:ispresented:actions:)-3npin) when the
-/// `ViewState` enters an error state.
+/// `ViewState` transitions into an error state.
 ///
 /// This is why the `error` state takes a
-/// [`LocalizedError`](https://developer.apple.com/documentation/foundation/localizederror) as an associated value;
+/// [`LocalizedError`](https://developer.apple.com/documentation/foundation/localizederror) as an associated value:
 /// it provides a localized error description for the alert that is presented to users.
 ///
 /// > Tip:
-/// > Use ``AnyLocalizedError`` for handling localized and non-localized errors at the same time. Non-localized
-/// > errors are handled on a best-effort basis, meaning that not always a description for them may be available.
+/// > Use ``AnyLocalizedError`` to handle both localized and non-localized errors simultaneously. Non-localized
+/// > errors are handled on a best-effort basis, meaning a description may not always be available.
 ///
 /// ```swift
 /// import SpeziViews
@@ -38,7 +38,7 @@ import Foundation
 ///             Button("Action") {
 ///                 viewState = .processing
 ///                 do {
-///                     // Call an asynchronouse function that may throw an error ...
+///                     // Call an asynchronous function that may throw an error...
 ///                     viewState = .idle
 ///                 } catch {
 ///                     viewState = .error(AnyLocalizedError(error: error))
@@ -51,10 +51,9 @@ import Foundation
 /// ```
 ///
 /// > Tip:
-/// > To avoid having to handle state changes manually (as seen above), an `OperationState` can be mapped to a
-/// > `ViewState`, allowing the `ViewState` to react to changes in the application's `OperationState` as defined by the
-/// > ``OperationState/representation`` property. For instruction on how to define such a mapping, see the
-/// > ``OperationState`` documentation.
+/// > To handle more complex view states, you can use the ``OperationState`` protocol to map a more sophisticated state machine to `ViewState` instances, as defined
+/// > by the ``OperationState/representation`` property. This allows you to benefit from the same built-in behavior and modifiers that `ViewState` provides.
+/// > For instructions on defining such a mapping, refer to the ``OperationState`` documentation.
 public enum ViewState {
     /// The view is idle and displaying content.
     case idle

--- a/Sources/SpeziViews/Model/ViewState.swift
+++ b/Sources/SpeziViews/Model/ViewState.swift
@@ -30,15 +30,6 @@ import Foundation
 /// import SpeziViews
 /// import SwiftUI
 ///
-/// enum ProcessingError: LocalizedError {
-///     case resourceError
-/// }
-///
-/// func doSomeProcessing() throws {
-///     // Function may throw an error
-///     throw ProcessingError.resourceError
-/// }
-///
 /// struct ViewStateExample: View {
 ///     @State private var viewState: ViewState = .idle
 ///
@@ -47,7 +38,7 @@ import Foundation
 ///             Button("Action") {
 ///                 viewState = .processing
 ///                 do {
-///                     try doSomeProcessing()
+///                     // Call an asynchronouse function that may throw an error ...
 ///                     viewState = .idle
 ///                 } catch {
 ///                     viewState = .error(AnyLocalizedError(error: error))

--- a/Sources/SpeziViews/Model/ViewState.swift
+++ b/Sources/SpeziViews/Model/ViewState.swift
@@ -49,7 +49,8 @@ import Foundation
 /// }
 /// ```
 ///
-/// The ``SwiftUI/View/viewStateAlert(state:)-4wzs4`` view modifier can be used to automatically notify users when the
+/// The ``SwiftUI/View/viewStateAlert(state:)-4wzs4`` view modifier can be used to automatically notify users with an
+/// [`Alert`](https://developer.apple.com/documentation/swiftui/view/alert(_:ispresented:actions:)-3npin) when the
 /// `ViewState` enters an error state.
 ///
 /// > Tip:

--- a/Sources/SpeziViews/Model/ViewState.swift
+++ b/Sources/SpeziViews/Model/ViewState.swift
@@ -60,9 +60,10 @@ import Foundation
 /// ```
 ///
 /// > Tip:
-/// > To avoid having to handle state changes manually (as seen above), a `ViewState` can be mapped to an
-/// > `OperationState`, allowing the `ViewState` to change automatically when the application's internal state changes.
-/// > For instruction on how to define such a mapping, see the ``OperationState`` documentation.
+/// > To avoid having to handle state changes manually (as seen above), an `OperationState` can be mapped to a
+/// > `ViewState`, allowing the `ViewState` to react to changes in the application's `OperationState` as defined by the
+/// > ``OperationState/representation`` property. For instruction on how to define such a mapping, see the
+/// > ``OperationState`` documentation.
 public enum ViewState {
     /// The view is idle and displaying content.
     case idle

--- a/Sources/SpeziViews/Model/ViewState.swift
+++ b/Sources/SpeziViews/Model/ViewState.swift
@@ -27,7 +27,7 @@ import Foundation
 ///     throw ProcessingError.resourceError
 /// }
 ///
-/// struct OperationStateTestView: View {
+/// struct ViewStateExample: View {
 ///     @State private var viewState: ViewState = .idle
 ///
 ///     var body: some View {

--- a/Sources/SpeziViews/Model/ViewState.swift
+++ b/Sources/SpeziViews/Model/ViewState.swift
@@ -10,6 +10,52 @@ import Foundation
 
 
 /// Allows SwiftUI views to keep track of their state and communicate to outside views.
+///
+/// A `ViewState` provides a built-in mechanism for tracking the state of a Spezi UI component.
+/// A view can be in either an `idle`, `processing`, or `error` `ViewState`.
+///
+/// ```swift
+/// import SpeziViews
+/// import SwiftUI
+///
+/// enum ProcessingError: LocalizedError {
+///     case resourceError
+/// }
+///
+/// func doSomeProcessing() throws {
+///     // Function may throw an error
+///     throw ProcessingError.resourceError
+/// }
+///
+/// struct OperationStateTestView: View {
+///     @State private var viewState: ViewState = .idle
+///
+///     var body: some View {
+///         VStack {
+///             Button("Action") {
+///                 viewState = .processing
+///                 do {
+///                     try doSomeProcessing()
+///                     viewState = .idle
+///                 } catch let error as LocalizedError {
+///                     viewState = .error(error)
+///                 } catch {
+///                     print("An unknown error occurred: \(error)")
+///                 }
+///             }
+///             .viewStateAlert(state: $viewState)
+///         }
+///     }
+/// }
+/// ```
+///
+/// The ``SwiftUI/View/viewStateAlert(state:)-4wzs4`` view modifier can be used to automatically notify users when the
+/// `ViewState` enters an error state.
+///
+/// > Tip:
+/// > To avoid having to handle state changes manually (as seen above), a `ViewState` can be mapped to an
+/// > `OperationState`, allowing the `ViewState` to change automatically when the application's internal state changes.
+/// > For instruction on how to define such a mapping, see the ``OperationState`` documentation.
 public enum ViewState {
     /// The view is idle and displaying content.
     case idle


### PR DESCRIPTION
# Docs: Add ViewState Documentation

## :recycle: Current situation & Problem

As pointed out in https://github.com/StanfordSpezi/SpeziLLM/pull/61#discussion_r1720129130 , `ViewState` was lacking documentation.

## :gear: Release Notes 
* Add `ViewState` documentation.


## :books: Documentation
.


## :white_check_mark: Testing
.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
