### PR TITLE
main actor fix for xcode 16.2

### DIFF
--- a/Sources/SpeziViews/Views/Layout/HorizontalGeometryReader.swift
+++ b/Sources/SpeziViews/Views/Layout/HorizontalGeometryReader.swift
@@ -39,7 +39,9 @@ public struct HorizontalGeometryReader<Content: View>: View {
                 }
             )
             .onPreferenceChange(WidthPreferenceKey.self) { width in
-                self.width = width
+                Task { @MainActor in
+                    self.width = width
+                }
             }
     }
     


### PR DESCRIPTION
This pull request includes a change to the `HorizontalGeometryReader` component to ensure that the width update is performed on the main actor. This change improves thread safety and ensures that UI updates occur on the main thread.

* [`Sources/SpeziViews/Views/Layout/HorizontalGeometryReader.swift`](diffhunk://#diff-d1f206e8d0c3cedc9af2c650ef90312e6b4af32328d3fc1a65a56e676bda0a42R42-R46): Wrapped the width update in a `Task` with `@MainActor` to ensure it runs on the main thread.