### PR TITLE
Make `DynamicLayout` Conform to `Sendable`

### DIFF
--- a/Sources/SpeziViews/Views/Layout/DynamicHStack.swift
+++ b/Sources/SpeziViews/Views/Layout/DynamicHStack.swift
@@ -12,7 +12,7 @@ import SwiftUI
 /// Access the dynamic layout of a child view.
 ///
 /// Refer to the documentation of ``DynamicHStack`` on how to retrieve the current layout.
-public enum DynamicLayout {
+public enum DynamicLayout: Sendable {
     /// The layout is horizontal.
     case horizontal
     /// The layout is vertical.


### PR DESCRIPTION
# Make `DynamicLayout` Conform to `Sendable`

## :recycle: Current situation & Problem
I was receiving the following error when building `SpeziAccount`
```
SpeziAccount/Sources/SpeziAccount/Views/DataEntry/DateOfBirthPicker.swift:102:17
    main actor-isolated property 'layout' can not be mutated from a Sendable closure
                    layout = value
                    ^
```
The reason for this appears to be that `DynamicLayout` does not explicitly conform to the `Sendable` protocol.
This PR adds explicit conformance.


Related: https://github.com/StanfordSpezi/SpeziAccount/pull/82
Related but not necessarily relevant: https://github.com/swiftlang/swift/issues/76648

## :gear: Release Notes 
* Fix a build error in `SpeziAccount`


## :books: Documentation
* Fix the three build errors/warnings I was receiving.


## :white_check_mark: Testing
With https://github.com/StanfordSpezi/SpeziAccount/pull/82 and the changes in this PR, the build error(s) in `SpeziAccount` disappear.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).

What do you think?