### PR TITLE
Add new OptionSetPicker

### DIFF
--- a/Sources/SpeziViews/Resources/Localizable.xcstrings
+++ b/Sources/SpeziViews/Resources/Localizable.xcstrings
@@ -1,9 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "" : {
-
-    },
     "%lld selected" : {
 
     },
@@ -33,9 +30,6 @@
       }
     },
     "Dismiss" : {
-
-    },
-    "Empty" : {
 
     },
     "Error" : {
@@ -110,9 +104,6 @@
 
     },
     "Option %u" : {
-
-    },
-    "Test" : {
 
     }
   },

--- a/Sources/SpeziViews/Resources/Localizable.xcstrings
+++ b/Sources/SpeziViews/Resources/Localizable.xcstrings
@@ -1,6 +1,12 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "" : {
+
+    },
+    "%lld selected" : {
+
+    },
     "A" : {
 
     },
@@ -27,6 +33,9 @@
       }
     },
     "Dismiss" : {
+
+    },
+    "Empty" : {
 
     },
     "Error" : {
@@ -95,6 +104,15 @@
       }
     },
     "None" : {
+
+    },
+    "nothing selected" : {
+
+    },
+    "Option %u" : {
+
+    },
+    "Test" : {
 
     }
   },

--- a/Sources/SpeziViews/SpeziViews.docc/SpeziViews.md
+++ b/Sources/SpeziViews/SpeziViews.docc/SpeziViews.md
@@ -68,6 +68,7 @@ Default layouts and utilities to automatically adapt your view layouts to dynami
 - ``InfoButton``
 - ``DismissButton``
 - ``CaseIterablePicker``
+- ``OptionSetPicker``
 
 ### Displaying Text
 

--- a/Sources/SpeziViews/Views/Controls/OptionSetPicker.swift
+++ b/Sources/SpeziViews/Views/Controls/OptionSetPicker.swift
@@ -110,46 +110,91 @@ public struct OptionSetPicker<Label: View, Value: OptionSet & PickerValue>: View
             }
 #if !os(watchOS)
         case .menu:
-            Menu {
-                ForEach(Value.allCases, id: \.self) { value in
-                    toggle(for: value)
-                }
+            menu
+#endif
+        }
+    }
+
+    @ViewBuilder private var menu: some View {
+#if os(visionOS)
+        LabeledContent {
+            let menu = Menu {
+                menuContent
             } label: {
-                LabeledContent {
-                    HStack {
-                        if selectionCount < 2 {
-                            if let value = singleSelection {
-                                Text(value.localizedStringResource)
-                            } else {
-                                Text("nothing selected")
-                                    .italic()
-                            }
-                        } else {
-                            Text("\(selectionCount) selected")
-                        }
-                        Image(systemName: "chevron.up.chevron.down")
-                            .accessibilityHidden(true)
-                            .font(.footnote)
-                            .fontWeight(.medium)
-                    }
-                } label: {
-                    if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
-                        ViewBasedOnVisibility {
-                            EmptyView()
-                        } labeled: {
-                            label
-                                .foregroundStyle(Color.primary)
-                        }
-                    } else {
-                        label
-                            .foregroundStyle(Color.primary)
-                    }
-                }
+                menuContentLabel
             }
+            if #available(visionOS 2, *) {
+                menu
+                    .accessibilityLabel { label in
+                        label
+                        menuLabel
+                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityAddTraits(.isButton)
+            } else {
+                menu
+            }
+        } label: {
+            menuLabel
+                .accessibilityHidden(true)
+        }
+            .menuActionDismissBehavior(.disabled) // disable for multi selection
+#else
+        Menu {
+            menuContent
+        } label: {
+            LabeledContent {
+                menuContentLabel
+            } label: {
+                menuLabel
+            }
+        }
 #if !os(macOS)
-                .menuActionDismissBehavior(.disabled) // disable for multi selection
+        .menuActionDismissBehavior(.disabled) // disable for multi selection
 #endif
 #endif
+    }
+
+    @ViewBuilder private var menuLabel: some View {
+        if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+            ViewBasedOnVisibility {
+                EmptyView()
+            } labeled: {
+                label
+                    .foregroundStyle(Color.primary)
+            }
+        } else {
+            label
+                .foregroundStyle(Color.primary)
+        }
+    }
+
+    @ViewBuilder private var menuContent: some View {
+        ForEach(Value.allCases, id: \.self) { value in
+            toggle(for: value)
+        }
+    }
+
+    @ViewBuilder private var menuContentLabel: some View {
+        HStack {
+            selectionLabel
+            Image(systemName: "chevron.up.chevron.down")
+                .accessibilityHidden(true)
+                .font(.footnote)
+                .fontWeight(.medium)
+        }
+    }
+
+    private var selectionLabel: Text {
+        if selectionCount < 2 {
+            if let value = singleSelection {
+                Text(value.localizedStringResource)
+            } else {
+                Text("nothing selected")
+                    .italic()
+            }
+        } else {
+            Text("\(selectionCount) selected")
         }
     }
 

--- a/Sources/SpeziViews/Views/Controls/OptionSetPicker.swift
+++ b/Sources/SpeziViews/Views/Controls/OptionSetPicker.swift
@@ -47,10 +47,14 @@ private struct ViewBasedOnVisibility<Unlabeled: View, Labeled: View>: View {
 /// If you have a type that both conforms to [`OptionSet`](https://developer.apple.com/documentation/swift/optionset)  and
 /// ``PickerValue`` you can use this Picker for your `selection` value.
 ///
-/// - Note: `OptionSet` by definition allows the selection of multiple values. Therefore, `OptionSetPicker` is always implemented as an
-///     inline Picker (e.g., as part of a List view) and allows to selection one or more entries.
+/// `OptionSet` by definition allows the selection of multiple values.
 ///
 /// - Note: Displaying labels is only supported on iOS 18 and newer.
+///
+/// ## Topics
+///
+/// ### Styling
+/// - ``OptionSetPickerStyle``
 public struct OptionSetPicker<Label: View, Value: OptionSet & PickerValue>: View
     where Value.AllCases: RandomAccessCollection, Value == Value.Element {
     private let allowEmptySelection: Bool

--- a/Sources/SpeziViews/Views/Controls/OptionSetPicker.swift
+++ b/Sources/SpeziViews/Views/Controls/OptionSetPicker.swift
@@ -115,7 +115,6 @@ public struct OptionSetPicker<Label: View, Value: OptionSet & PickerValue>: View
                     toggle(for: value)
                 }
             } label: {
-                // TODO: use toggles instead!
                 LabeledContent {
                     HStack {
                         if selectionCount < 2 {
@@ -161,7 +160,12 @@ public struct OptionSetPicker<Label: View, Value: OptionSet & PickerValue>: View
     ///   - style: The style how the picker is displayed.
     ///   - allowEmptySelection: Flag indicating if an empty selection is allowed.
     ///   - label: The label view.
-    public init(selection: Binding<Value>, style: OptionSetPickerStyle = .automatic, allowEmptySelection: Bool = false, @ViewBuilder label: () -> Label) {
+    public init(
+        selection: Binding<Value>,
+        style: OptionSetPickerStyle = .automatic,
+        allowEmptySelection: Bool = false,
+        @ViewBuilder label: () -> Label
+    ) {
         self.style = style
         self.allowEmptySelection = allowEmptySelection
         self.label = label()

--- a/Sources/SpeziViews/Views/Controls/OptionSetPicker.swift
+++ b/Sources/SpeziViews/Views/Controls/OptionSetPicker.swift
@@ -115,6 +115,7 @@ public struct OptionSetPicker<Label: View, Value: OptionSet & PickerValue>: View
         }
     }
 
+#if !os(watchOS)
     @ViewBuilder private var menu: some View {
 #if os(visionOS)
         LabeledContent {
@@ -154,6 +155,7 @@ public struct OptionSetPicker<Label: View, Value: OptionSet & PickerValue>: View
 #endif
 #endif
     }
+#endif
 
     @ViewBuilder private var menuLabel: some View {
         if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {

--- a/Sources/SpeziViews/Views/Controls/OptionSetPicker.swift
+++ b/Sources/SpeziViews/Views/Controls/OptionSetPicker.swift
@@ -1,0 +1,225 @@
+//
+// This source file is part of the Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+/// The view style for an `OptionSetPicker`.
+public enum OptionSetPickerStyle {
+    /// The picker is rendered inline (e.g., in a List view).
+    case inline
+    /// The picker is rendered as a menu.
+    case menu
+}
+
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+private struct ViewBasedOnVisibility<Unlabeled: View, Labeled: View>: View {
+    private let unlabeled: Unlabeled
+    private let labeled: Labeled
+
+    @Environment(\.labelsVisibility)
+    private var labelsVisibility
+
+
+    var body: some View {
+        switch labelsVisibility {
+        case .hidden:
+            unlabeled
+        case .automatic, .visible:
+            labeled
+        }
+    }
+
+    init(@ViewBuilder unlabeled: () -> Unlabeled, @ViewBuilder labeled: () -> Labeled) {
+        self.unlabeled = unlabeled()
+        self.labeled = labeled()
+    }
+}
+
+
+/// Create a picker based on a `OptionSet` selection.
+///
+/// If you have a type that both conforms to [`OptionSet`](https://developer.apple.com/documentation/swift/optionset)  and
+/// ``PickerValue`` you can use this Picker for your `selection` value.
+///
+/// - Note: `OptionSet` by definition allows the selection of multiple values. Therefore, `OptionSetPicker` is always implemented as an
+///     inline Picker (e.g., as part of a List view) and allows to selection one or more entries.
+///
+/// - Note: Displaying labels is only supported on iOS 18 and newer.
+public struct OptionSetPicker<Label: View, Value: OptionSet & PickerValue>: View
+    where Value.AllCases: RandomAccessCollection, Value == Value.Element {
+    private let allowEmptySelection: Bool
+    private let style: OptionSetPickerStyle
+
+    private let label: Label
+
+    @Binding private var selection: Value
+
+    private var selectionCount: Int {
+        Value.allCases.count { value in
+            selection.contains(value)
+        }
+    }
+
+    private var singleSelection: Value? {
+        Value.allCases.first { value in
+            selection.contains(value)
+        }
+    }
+
+    public var body: some View {
+        switch style {
+        case .inline:
+            let view = ForEach(Value.allCases, id: \.self) { value in
+                button(for: value)
+            }
+
+            if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+                ViewBasedOnVisibility {
+                    view
+                } labeled: {
+                    Section {
+                        view
+                    } header: {
+                        label
+                    }
+                }
+            } else {
+                view
+            }
+        case .menu:
+            Menu {
+                ForEach(Value.allCases, id: \.self) { value in
+                    button(for: value)
+                }
+            } label: {
+                LabeledContent {
+                    HStack {
+                        if selectionCount < 2 {
+                            if let value = singleSelection {
+                                Text(value.localizedStringResource)
+                            } else {
+                                Text("nothing selected")
+                                    .italic()
+                            }
+                        } else {
+                            Text("\(selectionCount) selected")
+                        }
+                        Image(systemName: "chevron.up.chevron.down")
+                            .accessibilityHidden(true)
+                            .font(.footnote)
+                            .fontWeight(.medium)
+                    }
+                } label: {
+                    if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+                        ViewBasedOnVisibility {
+                            EmptyView()
+                        } labeled: {
+                            label
+                                .foregroundStyle(Color.primary)
+                        }
+                    } else {
+                        label
+                            .foregroundStyle(Color.primary)
+                    }
+                }
+            }
+                .menuActionDismissBehavior(.disabled) // disable for multi selection
+        }
+    }
+
+    
+    /// Create a new picker for your selection.
+    /// - Parameters:
+    ///   - selection: The `OptionSet`-based selection.
+    ///   - style: The style how the picker is displayed.
+    ///   - allowEmptySelection: Flag indicating if an empty selection is allowed.
+    ///   - label: The label view.
+    public init(selection: Binding<Value>, style: OptionSetPickerStyle = .menu, allowEmptySelection: Bool = false, @ViewBuilder label: () -> Label) {
+        self.style = style
+        self.allowEmptySelection = allowEmptySelection
+        self.label = label()
+        self._selection = selection
+    }
+    
+    /// Create a new picker for your selection.
+    /// - Parameters:
+    ///   - titleKey: The localized label.
+    ///   - selection: The `OptionSet`-based selection.
+    ///   - style: The style how the picker is displayed.
+    ///   - allowEmptySelection: Flag indicating if an empty selection is allowed.
+    public init(
+        _ titleKey: LocalizedStringResource,
+        selection: Binding<Value>,
+        style: OptionSetPickerStyle = .menu,
+        allowEmptySelection: Bool = false
+    ) where Label == Text {
+        self.init(selection: selection, style: style, allowEmptySelection: allowEmptySelection) {
+            Text(titleKey)
+        }
+    }
+
+    @ViewBuilder
+    private func button(for value: Value) -> some View {
+        Button {
+            if selection.contains(value) {
+                if selection != value || allowEmptySelection {
+                    selection.remove(value)
+                }
+            } else {
+                selection.insert(value)
+            }
+        } label: {
+            HStack {
+                Text(value.localizedStringResource)
+                    .tint(.primary)
+                Spacer()
+                if selection.contains(value) {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(Color.accentColor)
+                        .fontWeight(.semibold)
+                        .accessibilityHidden(true)
+                }
+            }
+        }
+    }
+}
+
+
+#if DEBUG
+extension PreviewLayout {
+    fileprivate struct Options: OptionSet, PickerValue {
+        var rawValue: UInt8
+
+        static let option1 = Options(rawValue: 1 << 0)
+        static let option2 = Options(rawValue: 1 << 1)
+
+        static let allCases: [Options] = [.option1, .option2]
+
+        init(rawValue: UInt8) {
+            self.rawValue = rawValue
+        }
+
+        var localizedStringResource: LocalizedStringResource {
+            "Option \(rawValue)"
+        }
+    }
+}
+
+#Preview {
+    @Previewable @State var selection: PreviewLayout.Options = []
+    @Previewable @State var picker: String = ""
+
+    List {
+        OptionSetPicker("Test", selection: $selection)
+        Picker("Test", selection: $picker) {
+            Text("Empty").tag("")
+        }
+    }
+}
+#endif

--- a/Sources/SpeziViews/Views/Controls/OptionSetPicker.swift
+++ b/Sources/SpeziViews/Views/Controls/OptionSetPicker.swift
@@ -14,7 +14,17 @@ public enum OptionSetPickerStyle {
     /// The picker is rendered inline (e.g., in a List view).
     case inline
     /// The picker is rendered as a menu.
+    @available(watchOS, unavailable)
     case menu
+
+    /// The default style for the platform.
+    public static var automatic: OptionSetPickerStyle {
+#if os(watchOS)
+        .inline
+#else
+        .menu
+#endif
+    }
 }
 
 
@@ -98,6 +108,7 @@ public struct OptionSetPicker<Label: View, Value: OptionSet & PickerValue>: View
             } else {
                 view
             }
+#if !os(watchOS)
         case .menu:
             Menu {
                 ForEach(Value.allCases, id: \.self) { value in
@@ -136,7 +147,10 @@ public struct OptionSetPicker<Label: View, Value: OptionSet & PickerValue>: View
                     }
                 }
             }
+#if !os(macOS)
                 .menuActionDismissBehavior(.disabled) // disable for multi selection
+#endif
+#endif
         }
     }
 
@@ -147,7 +161,7 @@ public struct OptionSetPicker<Label: View, Value: OptionSet & PickerValue>: View
     ///   - style: The style how the picker is displayed.
     ///   - allowEmptySelection: Flag indicating if an empty selection is allowed.
     ///   - label: The label view.
-    public init(selection: Binding<Value>, style: OptionSetPickerStyle = .menu, allowEmptySelection: Bool = false, @ViewBuilder label: () -> Label) {
+    public init(selection: Binding<Value>, style: OptionSetPickerStyle = .automatic, allowEmptySelection: Bool = false, @ViewBuilder label: () -> Label) {
         self.style = style
         self.allowEmptySelection = allowEmptySelection
         self.label = label()
@@ -163,7 +177,7 @@ public struct OptionSetPicker<Label: View, Value: OptionSet & PickerValue>: View
     public init(
         _ titleKey: LocalizedStringResource,
         selection: Binding<Value>,
-        style: OptionSetPickerStyle = .menu,
+        style: OptionSetPickerStyle = .automatic,
         allowEmptySelection: Bool = false
     ) where Label == Text {
         self.init(selection: selection, style: style, allowEmptySelection: allowEmptySelection) {

--- a/Tests/UITests/TestApp/Localizable.xcstrings
+++ b/Tests/UITests/TestApp/Localizable.xcstrings
@@ -41,9 +41,6 @@
     "CanvasTest" : {
 
     },
-    "Case Iterable Picker" : {
-
-    },
     "Center" : {
 
     },
@@ -113,6 +110,9 @@
     "Increment" : {
 
     },
+    "Inline Picker" : {
+
+    },
     "Input Valid: %@" : {
 
     },
@@ -163,7 +163,13 @@
     "Operation State: %@" : {
 
     },
+    "Option Set" : {
+
+    },
     "Password" : {
+
+    },
+    "Picker" : {
 
     },
     "Please enter your email address of your account. A email with an link to reset your password will be sent to the email address." : {

--- a/Tests/UITests/TestApp/ViewsTests/CaseIterablePickerTests.swift
+++ b/Tests/UITests/TestApp/ViewsTests/CaseIterablePickerTests.swift
@@ -32,10 +32,6 @@ struct MyOptionSet: OptionSet, PickerValue {
 
     var rawValue: UInt8
 
-    init(rawValue: UInt8) {
-        self.rawValue = rawValue
-    }
-
     var localizedStringResource: LocalizedStringResource {
         var components: [String] = []
 
@@ -47,6 +43,11 @@ struct MyOptionSet: OptionSet, PickerValue {
         }
 
         return "\(components.joined(separator: ", "))"
+    }
+
+
+    init(rawValue: UInt8) {
+        self.rawValue = rawValue
     }
 }
 

--- a/Tests/UITests/TestApp/ViewsTests/CaseIterablePickerTests.swift
+++ b/Tests/UITests/TestApp/ViewsTests/CaseIterablePickerTests.swift
@@ -24,19 +24,60 @@ enum SomeSelection: PickerValue {
     }
 }
 
+struct MyOptionSet: OptionSet, PickerValue {
+    static let option1 = MyOptionSet(rawValue: 1 << 0)
+    static let option2 = MyOptionSet(rawValue: 1 << 1)
+
+    static let allCases: [MyOptionSet] = [.option1, .option2]
+
+    var rawValue: UInt8
+
+    init(rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
+
+    var localizedStringResource: LocalizedStringResource {
+        var components: [String] = []
+
+        if self.contains(.option1) {
+            components.append("Option 1")
+        }
+        if self.contains(.option2) {
+            components.append("Option 2")
+        }
+
+        return "\(components.joined(separator: ", "))"
+    }
+}
+
 
 struct CaseIterablePickerTests: View {
     @State private var selection: SomeSelection?
 
     @State private var selection2: SomeSelection = .first
 
+    @State private var optionSetMenu: MyOptionSet = []
+
     var body: some View {
         List {
             CaseIterablePicker("Selection", selection: $selection)
 
             CaseIterablePicker("Second", selection: $selection2)
+
+            Section {
+                OptionSetPicker("Option Set", selection: $optionSetMenu)
+            }
+
+            OptionSetPicker("Inline Picker", selection: $optionSetMenu, style: .inline)
         }
-            .navigationTitle("Case Iterable Picker")
+            .navigationTitle("Picker")
             .navigationBarTitleDisplayMode(.inline)
     }
 }
+
+
+#if DEBUG
+#Preview {
+    CaseIterablePickerTests()
+}
+#endif

--- a/Tests/UITests/TestApp/ViewsTests/SpeziViewsTests.swift
+++ b/Tests/UITests/TestApp/ViewsTests/SpeziViewsTests.swift
@@ -30,7 +30,7 @@ enum SpeziViewsTests: String, TestAppTests {
     case button = "Buttons"
     case listRow = "List Row"
     case managedViewUpdate = "Managed View Update"
-    case caseIterablePicker = "Case Iterable Picker"
+    case caseIterablePicker = "Picker"
 
     
     #if canImport(PencilKit) && !os(macOS)

--- a/Tests/UITests/TestAppUITests/SpeziViews/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/SpeziViews/ViewsTests.swift
@@ -232,7 +232,7 @@ final class ViewsTests: XCTestCase {
     }
 
     @MainActor
-    func testCaseIterablePicker() {
+    func testPickers() throws {
         let app = XCUIApplication()
         app.launch()
 
@@ -241,12 +241,11 @@ final class ViewsTests: XCTestCase {
 
         app.collectionViews.firstMatch.swipeUp() // out of the window on visionOS and iPadOs
 
-        XCTAssert(app.buttons["Case Iterable Picker"].waitForExistence(timeout: 2.0))
-        app.buttons["Case Iterable Picker"].tap()
+        XCTAssert(app.buttons["Picker"].waitForExistence(timeout: 2.0))
+        app.buttons["Picker"].tap()
 
-        XCTAssert(app.navigationBars.staticTexts["Case Iterable Picker"].waitForExistence(timeout: 2.0))
+        XCTAssert(app.navigationBars.staticTexts["Picker"].waitForExistence(timeout: 2.0))
 
-        print(app.debugDescription)
         XCTAssert(app.buttons["Selection, None"].exists)
         app.buttons["Selection, None"].tap()
 
@@ -257,5 +256,13 @@ final class ViewsTests: XCTestCase {
         app.buttons["First"].tap()
 
         XCTAssert(app.buttons["Selection, First"].waitForExistence(timeout: 2.0))
+
+        // OPTION SET
+
+        XCTAssert(app.buttons["Option Set, nothing selected"].exists)
+        app.buttons["Option Set, nothing selected"].tap()
+
+        XCTAssert(app.buttons["Option 1"].firstMatch.waitForExistence(timeout: 1.0))
+        app.buttons["Option 1"].firstMatch.tap()
     }
 }

--- a/Tests/UITests/TestAppUITests/SpeziViews/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/SpeziViews/ViewsTests.swift
@@ -259,8 +259,13 @@ final class ViewsTests: XCTestCase {
 
         // OPTION SET
 
+#if os(visionOS)
+        XCTAssert(app.staticTexts["nothing selected"].exists)
+        app.staticTexts["nothing selected"].tap()
+#else
         XCTAssert(app.buttons["Option Set, nothing selected"].exists)
         app.buttons["Option Set, nothing selected"].tap()
+#endif
 
         XCTAssert(app.buttons["Option 1"].firstMatch.waitForExistence(timeout: 1.0))
         app.buttons["Option 1"].firstMatch.tap()


### PR DESCRIPTION
# Add new option set picker

## :recycle: Current situation & Problem
This PR adds a new view that makes it easier to work with OptionSet as the selection of a Picker view. SwiftUI `Picker` doesn't natively support multi-selection picker. The `OptionSetPicker` does that by facilitating the `OptionSet` protocol.
Sadly we cannot fully re-use `PickerStyles` and needed to create our own enum-based solution. Currently we support rendering the picker as a `menu` or a `inline` view like, e.g., in a `List`.


## :gear: Release Notes 
* Added new `OptionSetPicker` view.


## :books: Documentation
Added documentation and added it to the DocC catalog.


## :white_check_mark: Testing
Added new UI tests.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
