### PR TITLE
fix `swift build`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,6 +39,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Spezi", package: "Spezi")
             ],
+            resources: [.process("Resources")],
             plugins: [] + swiftLintPlugin()
         ),
         .target(
@@ -46,6 +47,7 @@ let package = Package(
             dependencies: [
                 .target(name: "SpeziViews")
             ],
+            resources: [.process("Resources")],
             plugins: [] + swiftLintPlugin()
         ),
         .target(
@@ -54,6 +56,7 @@ let package = Package(
                 .target(name: "SpeziViews"),
                 .product(name: "OrderedCollections", package: "swift-collections")
             ],
+            resources: [.process("Resources")],
             plugins: [] + swiftLintPlugin()
         ),
         .testTarget(


### PR DESCRIPTION
# fix `swift build`

## :recycle: Current situation & Problem
Compiling SpeziViews using `swift build` currently fails, with compiler errors complaining about other packages' `Bundle.module` extensions being internal.
Compiling SpeziViews using Xcode or `xcodebuild`, on the other hand, works fine.
As it turns out, this is caused by Xcode's build system having different rules for automatic processing of target resources than what the `swift build` does: Xcode will implicitly generate the `Bundle.module` extension for each of SpeziView's targets, since each target contains a `Resources/Localizable.xcstrings` file.
Since the `swift build` command will not do this on its own, we need to explicitly add these `Resources` folders to the package manifest.

## :gear: Release Notes
- SpeziViews can now also be compiled using `swift build`

## :books: Documentation
n/a

## :white_check_mark: Testing
n/a

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
