### PR TITLE
fix SpeziFoundation dependency version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.8.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.0.1"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.1.3"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.17.0")
     ] + swiftLintPackage(),


### PR DESCRIPTION
# fix SpeziFoundation dependency version

## :recycle: Current situation & Problem
A recent SpeziViews PR (#57) introduced a dependency on a SpeziFoundation feature which was added in SpeziFoundation 2.1.2, but didn't update the minimum required SpeziFoundation version in SpeziViews' Package.swift.

At the time, this wasn't noticed, since Xcode always resolved the packages in a way that fetched the newest SpeziFoundation release.
Hoewer, this can cause issues in some cases, e.g. when SpeziViews is used as a dependency of another package.

This PR fixes this, by updating the SpeziFoundation dependency to the correct minimum version


## :gear: Release Notes
- fixed incorrect SpeziFoundation min version


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
