### PR TITLE
make `AnyLocalizedError` descriptions more descriptive in Debug/Test builds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,7 @@ let package = Package(
                 .product(name: "SpeziFoundation", package: "SpeziFoundation")
             ],
             resources: [.process("Resources")],
+            swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()
         ),
         .target(
@@ -49,6 +50,7 @@ let package = Package(
                 .target(name: "SpeziViews")
             ],
             resources: [.process("Resources")],
+            swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()
         ),
         .target(
@@ -59,6 +61,7 @@ let package = Package(
                 .product(name: "OrderedCollections", package: "swift-collections")
             ],
             resources: [.process("Resources")],
+            swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()
         ),
         .testTarget(
@@ -68,6 +71,7 @@ let package = Package(
                 .target(name: "SpeziValidation"),
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing")
             ],
+            swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()
         )
     ]

--- a/Sources/SpeziValidation/ValidationRule.swift
+++ b/Sources/SpeziValidation/ValidationRule.swift
@@ -173,7 +173,7 @@ extension ValidationRule: Decodable {
         case message
     }
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
 
         let regexString = try values.decode(String.self, forKey: .rule)

--- a/Sources/SpeziViews/Model/ViewState.swift
+++ b/Sources/SpeziViews/Model/ViewState.swift
@@ -60,7 +60,7 @@ public enum ViewState {
     /// The view is in a processing state, e.g. loading content.
     case processing
     /// The view is in an error state, e.g., loading the content failed.
-    case error(LocalizedError)
+    case error(any LocalizedError)
 }
 
 

--- a/Sources/SpeziViews/Utilities/AnyLocalizedError.swift
+++ b/Sources/SpeziViews/Utilities/AnyLocalizedError.swift
@@ -31,8 +31,11 @@ public struct AnyLocalizedError: LocalizedError {
     /// - Parameters:
     ///   - error: The error instance that should be wrapped.
     ///   - defaultErrorDescription: The localized default error description that should be used if the `error` does not provide any context to create an error description.
-    public init(error: Error, defaultErrorDescription: LocalizedStringResource? = nil) {
-        self.init(error: error, defaultErrorDescription: String(localized: defaultErrorDescription ?? Self.globalDefaultErrorDescription))
+    public init(error: any Error, defaultErrorDescription: LocalizedStringResource? = nil) {
+        self.init(
+            error: error,
+            defaultErrorDescription: String(localized: defaultErrorDescription ?? Self.globalDefaultErrorDescription)
+        )
     }
     
     /// Provides a best-effort approach to create a type erased version of `LocalizedError`.
@@ -43,14 +46,14 @@ public struct AnyLocalizedError: LocalizedError {
     /// - Parameters:
     ///   - error: The error instance that should be wrapped.
     ///   - defaultErrorDescription: The localized default error description that should be used if the `error` does not provide any context to create an error description.
-    public init(error: Error, defaultErrorDescription: String) {
+    public init(error: any Error, defaultErrorDescription: String) {
         switch error {
-        case let localizedError as LocalizedError:
-            self.errorDescription = localizedError.errorDescription ?? defaultErrorDescription
-            self.failureReason = localizedError.failureReason
-            self.helpAnchor = localizedError.helpAnchor
-            self.recoverySuggestion = localizedError.recoverySuggestion
-        case let customStringConvertible as CustomStringConvertible:
+        case let error as any LocalizedError:
+            self.errorDescription = error.errorDescription ?? defaultErrorDescription
+            self.failureReason = error.failureReason
+            self.helpAnchor = error.helpAnchor
+            self.recoverySuggestion = error.recoverySuggestion
+        case let customStringConvertible as any CustomStringConvertible:
             self.errorDescription = customStringConvertible.description
         default:
             self.errorDescription = defaultErrorDescription

--- a/Sources/SpeziViews/Utilities/AnyLocalizedError.swift
+++ b/Sources/SpeziViews/Utilities/AnyLocalizedError.swift
@@ -31,13 +31,14 @@ public struct AnyLocalizedError: LocalizedError {
     /// - Parameters:
     ///   - error: The error instance that should be wrapped.
     ///   - defaultErrorDescription: The localized default error description that should be used if the `error` does not provide any context to create an error description.
+    ///       In `DEBUG` and `TEST` builds, specifying `nil` here will default to a description derived via `String(reflecting:)`.
     public init(error: any Error, defaultErrorDescription: @autoclosure () -> LocalizedStringResource? = nil) {
         self.init(error: error, defaultErrorDescription: {
             if let desc = defaultErrorDescription().map({ String(localized: $0) }) {
                 return desc
             }
             #if DEBUG || TEST
-            return "\(error)"
+            return String(reflecting: error)
             #endif
             return String(localized: Self.globalDefaultErrorDescription)
         }())


### PR DESCRIPTION
# make `AnyLocalizedError` descriptions more descriptive in Debug/Test builds

## :recycle: Current situation & Problem
We currently sometimes have (seemingly random) test failures in some packages' UI tests, in views that use a `ViewState` with an associated alert.
The idea behind this PR is to increase the amount of debuggable information displayed in the UI in these cases, so that we can more easily figure out what exactly went wrong (based eg on the XCTest recording).
Since we probably don't want such internal descriptions, which in most cases won't be intended to be publicly displayed, to be user-visible, we limit these changes to `DEBUG` and `TEST` builds.


## :gear: Release Notes
n/a

## :books: Documentation
the docs have been updated to document this behaviour

## :white_check_mark: Testing
n/a

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
