### PR TITLE
Support different processing styles with AsyncButton and update internals

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,7 +13,7 @@ SpeziViews contributors
 
 * [Paul Schmiedmayer](https://github.com/PSchmiedmayer)
 * [Vishnu Ravi](https://github.com/vishnuravi)
-* [Andreas Bauer](https://github.com/Supereg)
+* [Andreas Bauer](https://github.com/bauer-andreas)
 * [Philipp Zagar](https://github.com/philippzagar)
 * [Nikolai Madlener](https://github.com/nikolaimadlener)
 * [Lukas Kollmer](https://github.com/lukaskollmer)

--- a/Sources/SpeziViews/SpeziViews.docc/SpeziViews.md
+++ b/Sources/SpeziViews/SpeziViews.docc/SpeziViews.md
@@ -64,6 +64,7 @@ Default layouts and utilities to automatically adapt your view layouts to dynami
 
 - ``AsyncButton``
 - ``SwiftUICore/EnvironmentValues/processingDebounceDuration``
+- ``SwiftUICore/View/asyncButtonProcessingStyle(_:)``
 - ``CanvasView``
 - ``InfoButton``
 - ``DismissButton``

--- a/Sources/SpeziViews/Views/Button/AsyncButton.swift
+++ b/Sources/SpeziViews/Views/Button/AsyncButton.swift
@@ -34,19 +34,61 @@ enum AsyncButtonState {
 ///         .viewStateAlert(state: $viewState)
 /// }
 /// ```
+///
+/// ### Decouple Task Lifetime
+///
+/// A restriction of `AsyncButton` is that the task lifetime is bound to the appearance of the `Button` view. In certain cases (e.g., alert buttons or swipe action buttons), you might want to
+/// continue running the task even if the button view disappears and bind the lifetime of the task to a view higher up the view hierarchy.
+/// In these cases, you might want to use a pattern like the following and manage the lifetime yourself:
+///
+/// ```swift
+/// struct MyView: View {
+///     private enum Event {
+///         case myEvent(String)
+///     }
+///
+///     @State private var events: (stream: AsyncStream<Event>, continuation: AsyncStream<Event>.Continuation) = AsyncStream.makeStream()
+///
+///     var body: some View {
+///         List(elements) { element in
+///             Button("Remove") {
+///                 events.continuation.yield(.myEvent(element))
+///             }
+///         }
+///             .task {
+///                 events = AsyncStream.makeStream() // durability over multiple appears
+///                 for await event in events.stream {
+///                     // perform action and manage state
+///                 }
+///             }
+///     }
+/// }
+/// ```
 @MainActor
 public struct AsyncButton<Label: View>: View {
+    private enum GroupResult {
+        case debounce
+        case result(Result<Void, any Error>)
+    }
+
+    private enum Event {
+        case runAction
+    }
+
     private let role: ButtonRole?
     private let action: @MainActor () async throws -> Void
     private let label: Label
 
     @Environment(\.defaultErrorDescription)
-    var defaultErrorDescription
+    private var defaultErrorDescription
     @Environment(\.processingDebounceDuration)
-    var processingDebounceDuration
+    private var processingDebounceDuration
+    @Environment(\.asyncButtonProcessingStyle)
+    private var processingStyle
+    @Environment(\.isEnabled)
+    private var isEnabled
 
-    @State private var actionTask: Task<Void, Never>?
-
+    @State private var actionSignal: (stream: AsyncStream<Event>, continuation: AsyncStream<Event>.Continuation) = AsyncStream.makeStream()
     @State private var buttonState: AsyncButtonState = .idle
     @Binding private var viewState: ViewState
 
@@ -56,14 +98,41 @@ public struct AsyncButton<Label: View>: View {
         buttonState == .idle && viewState == .processing
     }
 
+    private var isConsideredProcessing: Bool {
+        buttonState == .disabledAndProcessing || externallyProcessing
+    }
+
+    private var consideredDisabled: Bool {
+        !isEnabled || buttonState != .idle || externallyProcessing
+    }
+
     public var body: some View {
         Button(role: role, action: submitAction) {
-            label
-                .processingOverlay(isProcessing: buttonState == .disabledAndProcessing || externallyProcessing)
+            switch processingStyle {
+            case .overlay:
+                label
+                    .processingOverlay(isProcessing: isConsideredProcessing)
+            case .listRow:
+                ListRow {
+                    label
+                        .foregroundStyle(consideredDisabled ? .tertiary : .primary)
+                } content: {
+                    if isConsideredProcessing {
+                        ProgressView()
+                    }
+                }
+
+            }
         }
-            .disabled(buttonState != .idle || externallyProcessing)
-            .onDisappear {
-                actionTask?.cancel()
+            .disabled(consideredDisabled)
+            .task {
+                actionSignal = AsyncStream.makeStream()
+                for await event in actionSignal.stream {
+                    switch event {
+                    case .runAction:
+                        await self.runAction()
+                    }
+                }
             }
     }
 
@@ -172,41 +241,71 @@ public struct AsyncButton<Label: View>: View {
 
 
     private func submitAction() {
-        guard viewState != .processing else {
+        guard buttonState == .idle else {
             return
         }
 
         buttonState = .disabled
 
+        self.actionSignal.continuation.yield(.runAction)
+    }
+
+    private func runAction() async {
+        guard buttonState == .disabled else {
+            return
+        }
+
+        defer {
+            buttonState = .idle
+        }
+
         withAnimation(.easeOut(duration: 0.2)) {
             viewState = .processing
         }
 
-        actionTask = Task {
-            let debounce = Task {
+        let result = await withTaskGroup(of: GroupResult.self) { group in
+            group.addTask {
                 await debounceProcessingIndicator()
+                return .debounce
             }
 
-            do {
-                try await action()
-                debounce.cancel()
-
-                // the button action might set the state back to idle to prevent this animation
-                if viewState != .idle {
-                    withAnimation(.easeIn(duration: 0.2)) {
-                        viewState = .idle
-                    }
+            group.addTask {
+                do {
+                    return .result(.success(try await action()))
+                } catch {
+                    return .result(.failure(error))
                 }
-            } catch {
-                debounce.cancel()
-                viewState = .error(AnyLocalizedError(
-                    error: error,
-                    defaultErrorDescription: defaultErrorDescription
-                ))
             }
 
-            buttonState = .idle
-            actionTask = nil
+            let first = await group.next()!
+
+            if case .result = first {
+                group.cancelAll() // cancel the debounce
+            }
+
+            let second = await group.next()!
+
+            switch (first, second) {
+            case (let .result(result), .debounce), (.debounce, let .result(result)):
+                return result
+            case (.debounce, .debounce), (.result, .result):
+                fatalError("GroupTask inconsistency.")
+            }
+        }
+
+        switch result {
+        case .success:
+            // the button action might set the state back to idle to prevent this animation
+            if viewState != .idle {
+                withAnimation(.easeIn(duration: 0.2)) {
+                    viewState = .idle
+                }
+            }
+        case let .failure(error):
+            viewState = .error(AnyLocalizedError(
+                error: error,
+                defaultErrorDescription: defaultErrorDescription
+            ))
         }
     }
 

--- a/Sources/SpeziViews/Views/Button/AsyncButton.swift
+++ b/Sources/SpeziViews/Views/Button/AsyncButton.swift
@@ -121,7 +121,6 @@ public struct AsyncButton<Label: View>: View {
                         ProgressView()
                     }
                 }
-
             }
         }
             .disabled(consideredDisabled)
@@ -277,19 +276,23 @@ public struct AsyncButton<Label: View>: View {
                 }
             }
 
-            let first = await group.next()!
+            guard let first = await group.next() else {
+                fatalError("Unexpected TaskGroup state.")
+            }
 
             if case .result = first {
                 group.cancelAll() // cancel the debounce
             }
 
-            let second = await group.next()!
+            guard let second = await group.next() else {
+                fatalError("Unexpected TaskGroup state.")
+            }
 
             switch (first, second) {
             case (let .result(result), .debounce), (.debounce, let .result(result)):
                 return result
             case (.debounce, .debounce), (.result, .result):
-                fatalError("GroupTask inconsistency.")
+                fatalError("TaskGroup inconsistency.")
             }
         }
 

--- a/Sources/SpeziViews/Views/Button/AsyncButtonProcessingStyle.swift
+++ b/Sources/SpeziViews/Views/Button/AsyncButtonProcessingStyle.swift
@@ -9,8 +9,11 @@
 import SwiftUI
 
 
+/// Define how an `AsyncButton` visualizes it's processing state.
 public enum AsyncButtonProcessingStyle: Hashable, Sendable {
+    /// Draw a `ProgressView` as an overlay replacing the button view.
     case overlay
+    /// Draw a `ProgressView` next to the button label.
     case listRow
 }
 
@@ -20,6 +23,9 @@ extension EnvironmentValues {
 
 
 extension View {
+    /// Define how an `AsyncButton` visualizes it's processing state.
+    /// - Parameter style: The processing style.
+    /// - Returns: Returns the modified view.
     public func asyncButtonProcessingStyle(_ style: AsyncButtonProcessingStyle) -> some View {
         environment(\.asyncButtonProcessingStyle, style)
     }

--- a/Sources/SpeziViews/Views/Button/AsyncButtonProcessingStyle.swift
+++ b/Sources/SpeziViews/Views/Button/AsyncButtonProcessingStyle.swift
@@ -1,0 +1,26 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+
+public enum AsyncButtonProcessingStyle: Hashable, Sendable {
+    case overlay
+    case listRow
+}
+
+extension EnvironmentValues {
+    @Entry var asyncButtonProcessingStyle: AsyncButtonProcessingStyle = .overlay
+}
+
+
+extension View {
+    public func asyncButtonProcessingStyle(_ style: AsyncButtonProcessingStyle) -> some View {
+        environment(\.asyncButtonProcessingStyle, style)
+    }
+}

--- a/Sources/SpeziViews/Views/Drawing/CanvasView.swift
+++ b/Sources/SpeziViews/Views/Drawing/CanvasView.swift
@@ -22,21 +22,15 @@ private struct _CanvasView: UIViewRepresentable {
         
         
         func canvasViewDidBeginUsingTool(_ pkCanvasView: PKCanvasView) {
-            Task { @MainActor in
-                canvasView.isDrawing = true
-            }
+            canvasView.isDrawing = true
         }
         
         func canvasViewDidEndUsingTool(_ pkCanvasView: PKCanvasView) {
-            Task { @MainActor in
-                canvasView.isDrawing = false
-            }
+            canvasView.isDrawing = false
         }
         
         func canvasViewDrawingDidChange(_ pkCanvasView: PKCanvasView) {
-            Task { @MainActor in
-                canvasView.drawing = pkCanvasView.drawing
-            }
+            canvasView.drawing = pkCanvasView.drawing
         }
     }
     
@@ -82,9 +76,7 @@ private struct _CanvasView: UIViewRepresentable {
         picker.setVisible(showToolPicker, forFirstResponder: canvasView)
         
         if showToolPicker {
-            Task { @MainActor in
-                canvasView.becomeFirstResponder()
-            }
+            canvasView.becomeFirstResponder()
         }
     }
     

--- a/Tests/UITests/TestApp/ViewsTests/ButtonTestView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/ButtonTestView.swift
@@ -45,9 +45,10 @@ struct ButtonTestView: View {
                     showCompleted = true
                 }
                 AsyncButton("Hello Throwing World", role: .destructive, state: $viewState) {
-                    try await Task.sleep(for: .milliseconds(20))
+                    try await Task.sleep(for: .milliseconds(500))
                     throw CustomError.error
                 }
+                    .asyncButtonProcessingStyle(.listRow)
             }
                 .disabled(showCompleted)
                 .viewStateAlert(state: $viewState)


### PR DESCRIPTION
# Support different processing styles with AsyncButton and update internals

## :recycle: Current situation & Problem
`AsyncButton` doesn't provide the best layout by default when used with a List as a list row. We added a new `asyncButtonProcessingStyle(_:)` modifier that provides additional styles for drawing a processing `AsyncButton`.

Further, the internal handling of `AsyncButton` wasn't a great example on how to use structured concurrency with SwiftUI. We re-wrote some of the task-handling internals to get rid of unstructured tasks and make a great example.
Additionally, we included the general approach as part of the documentation of `AsyncButton`. In cases where you canon use `AsyncButton` due to the limited task lifetime, the documentation now highlights how you can approach such a situation.

## :gear: Release Notes
* Embrace structured concurrency with AsyncButton.
* Add `asyncButtonProcessingStyle(_:)` modifier

## :books: Documentation
Updated DocC catalog.


## :white_check_mark: Testing
Used existing test suite.


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
