### PR TITLE
CanvasView: respect `.disabled(_:)` modifier, allow updating drawing through binding

### DIFF
--- a/Sources/SpeziViews/Views/Drawing/CanvasView.swift
+++ b/Sources/SpeziViews/Views/Drawing/CanvasView.swift
@@ -78,6 +78,9 @@ private struct _CanvasView: UIViewRepresentable {
         if showToolPicker {
             canvasView.becomeFirstResponder()
         }
+        if #available(iOS 18.0, *) {
+            canvasView.isDrawingEnabled = context.environment.isEnabled
+        }
     }
     
     func makeCoordinator() -> Coordinator {

--- a/Sources/SpeziViews/Views/Drawing/CanvasView.swift
+++ b/Sources/SpeziViews/Views/Drawing/CanvasView.swift
@@ -74,6 +74,9 @@ private struct _CanvasView: UIViewRepresentable {
     func updateUIView(_ canvasView: PKCanvasView, context: Context) {
         picker.addObserver(canvasView)
         picker.setVisible(showToolPicker, forFirstResponder: canvasView)
+        if canvasView.drawing != drawing {
+            canvasView.drawing = drawing
+        }
         
         if showToolPicker {
             canvasView.becomeFirstResponder()

--- a/Sources/SpeziViews/Views/Drawing/CanvasView.swift
+++ b/Sources/SpeziViews/Views/Drawing/CanvasView.swift
@@ -78,7 +78,7 @@ private struct _CanvasView: UIViewRepresentable {
         if showToolPicker {
             canvasView.becomeFirstResponder()
         }
-        if #available(iOS 18.0, *) {
+        if #available(iOS 18.0, visionOS 2.0, *) {
             canvasView.isDrawingEnabled = context.environment.isEnabled
         }
     }

--- a/Tests/UITests/TestApp/Localizable.xcstrings
+++ b/Tests/UITests/TestApp/Localizable.xcstrings
@@ -50,6 +50,9 @@
     "Clean Code" : {
 
     },
+    "Clear Canvas" : {
+
+    },
     "Closure Condition present" : {
 
     },

--- a/Tests/UITests/TestApp/Localizable.xcstrings
+++ b/Tests/UITests/TestApp/Localizable.xcstrings
@@ -77,6 +77,12 @@
     "Email" : {
 
     },
+    "Enable/Disable Canvas" : {
+
+    },
+    "Enable/Disable Canvas, %@" : {
+
+    },
     "Enter your details" : {
 
     },

--- a/Tests/UITests/TestApp/ViewsTests/CanvasTestView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/CanvasTestView.swift
@@ -19,21 +19,35 @@ struct CanvasTestView: View {
     @State var showToolPicker = false
     @State var drawing = PKDrawing()
     @State var receivedSize: CGSize?
+    @State var enableDrawing = true
 
     @State private var values: (stream: AsyncStream<CGSize>, continuation: AsyncStream<CGSize>.Continuation) = AsyncStream.makeStream()
 
     var body: some View {
         ZStack {
             VStack {
-                Text("Did Draw Anything: \(didDrawAnything.description)")
-                if let receivedSize {
-                    Text("Canvas Size: width \(receivedSize.width), height \(receivedSize.height)")
-                } else {
-                    Text("Canvas Size: none")
+                Group {
+                    Text("Did Draw Anything: \(didDrawAnything.description)")
+                    if let receivedSize {
+                        Text("Canvas Size: width \(receivedSize.width), height \(receivedSize.height)")
+                    } else {
+                        Text("Canvas Size: none")
+                    }
+                    Button("Show Tool Picker") {
+                        showToolPicker.toggle()
+                    }
+                    HStack {
+                        Button("Enable/Disable Canvas") {
+                            enableDrawing.toggle()
+                        }
+                        Spacer()
+                        Text(enableDrawing.description)
+                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("Enable/Disable Canvas, \(enableDrawing.description)")
                 }
-                Button("Show Tool Picker") {
-                    showToolPicker.toggle()
-                }
+                .padding(.horizontal)
+                Divider()
                 CanvasView(
                     drawing: $drawing,
                     isDrawing: $isDrawing,
@@ -41,6 +55,7 @@ struct CanvasTestView: View {
                     drawingPolicy: .anyInput,
                     showToolPicker: $showToolPicker
                 )
+                .disabled(!enableDrawing)
             }
         }
             .onChange(of: isDrawing) {
@@ -64,6 +79,7 @@ struct CanvasTestView: View {
                 }
                 values = AsyncStream.makeStream()
             }
+            .interactiveDismissDisabled()
     }
 }
 

--- a/Tests/UITests/TestApp/ViewsTests/CanvasTestView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/CanvasTestView.swift
@@ -14,14 +14,15 @@ import SwiftUI
 
 
 struct CanvasTestView: View {
-    @State var isDrawing = false
-    @State var didDrawAnything = false
-    @State var showToolPicker = false
-    @State var drawing = PKDrawing()
-    @State var receivedSize: CGSize?
-    @State var enableDrawing = true
-
-    @State private var values: (stream: AsyncStream<CGSize>, continuation: AsyncStream<CGSize>.Continuation) = AsyncStream.makeStream()
+    @State private var isDrawing = false
+    @State private var showToolPicker = false
+    @State private var drawing = PKDrawing()
+    @State private var receivedSize: CGSize?
+    @State private var enableDrawing = true
+    @State private var values = AsyncStream.makeStream(of: CGSize.self)
+    var didDrawAnything: Bool {
+        !drawing.strokes.isEmpty
+    }
 
     var body: some View {
         ZStack {
@@ -45,6 +46,9 @@ struct CanvasTestView: View {
                     }
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel("Enable/Disable Canvas, \(enableDrawing.description)")
+                    Button("Clear Canvas") {
+                        drawing.strokes.removeAll()
+                    }
                 }
                 .padding(.horizontal)
                 Divider()
@@ -58,11 +62,6 @@ struct CanvasTestView: View {
                 .disabled(!enableDrawing)
             }
         }
-            .onChange(of: isDrawing) {
-                if isDrawing {
-                    didDrawAnything = true
-                }
-            }
             .navigationBarTitleDisplayMode(.inline)
             .onPreferenceChange(CanvasView.CanvasSizePreferenceKey.self) { size in
                 if Thread.isMainThread {

--- a/Tests/UITests/TestAppUITests/SpeziViews/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/SpeziViews/ViewsTests.swift
@@ -69,6 +69,45 @@ final class ViewsTests: XCTestCase {
         canvasView.swipeUp()
     }
     
+    
+    @MainActor
+    func testCanvasDisable() throws {
+#if !canImport(PencilKit) || os(macOS)
+        throw XCTSkip("PencilKit is not supported on this platform")
+#endif
+        
+#if targetEnvironment(simulator) && (arch(i386) || arch(x86_64))
+        throw XCTSkip("PKCanvas view-related tests are currently skipped on Intel-based iOS simulators due to a metal bug on the simulator.")
+#endif
+
+        let app = XCUIApplication()
+        app.launch()
+
+        app.open(target: "SpeziViews")
+
+        XCTAssert(app.collectionViews.buttons["Canvas"].waitForExistence(timeout: 2))
+        app.collectionViews.buttons["Canvas"].tap()
+        XCTAssert(app.staticTexts["Did Draw Anything: false"].waitForExistence(timeout: 2))
+        
+        let canvasView = app.scrollViews.firstMatch
+        
+        XCTAssert(app.buttons["Enable/Disable Canvas, true"].waitForExistence(timeout: 2))
+        app.buttons["Enable/Disable Canvas"].tap()
+        XCTAssert(app.buttons["Enable/Disable Canvas, false"].waitForExistence(timeout: 2))
+        // the "swipe down" action here will, since the CanvasView is disabled, attempt to dismiss the sheet,
+        // which will fail since we have explicitly disabled the CanvasTestView's interactive dismissal.
+        canvasView.swipeRight()
+        canvasView.swipeDown()
+        XCTAssert(app.staticTexts["Did Draw Anything: false"].waitForExistence(timeout: 2))
+        
+        app.buttons["Enable/Disable Canvas"].tap()
+        XCTAssert(app.buttons["Enable/Disable Canvas, true"].waitForExistence(timeout: 2))
+        canvasView.swipeRight()
+        canvasView.swipeDown()
+        XCTAssert(app.staticTexts["Did Draw Anything: true"].waitForExistence(timeout: 2))
+    }
+    
+    
     @MainActor
     func testGeometryReader() throws {
         let app = XCUIApplication()

--- a/Tests/UITests/TestAppUITests/SpeziViews/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/SpeziViews/ViewsTests.swift
@@ -70,8 +70,11 @@ final class ViewsTests: XCTestCase {
     }
     
     
+    // Tests:
+    // - that the CanvasView properly respects the `.disabled(_:)` view modifier,
+    // - that mutating the drawing through the binding causes the CanvasView to update its state.
     @MainActor
-    func testCanvasDisable() throws {
+    func testCanvasDisableAndMutateThroughBinding() throws {
 #if !canImport(PencilKit) || os(macOS)
         throw XCTSkip("PencilKit is not supported on this platform")
 #endif
@@ -105,6 +108,9 @@ final class ViewsTests: XCTestCase {
         canvasView.swipeRight()
         canvasView.swipeDown()
         XCTAssert(app.staticTexts["Did Draw Anything: true"].waitForExistence(timeout: 2))
+        
+        app.buttons["Clear Canvas"].tap()
+        XCTAssert(app.staticTexts["Did Draw Anything: false"].waitForExistence(timeout: 2))
     }
     
     


### PR DESCRIPTION
# CanvasView: respect `.disabled(_:)` modifier, allow updating drawing through binding

## :recycle: Current situation & Problem
Changes the `CanvasView` to:
1. take the `isEnabled` environment value into account and propagate it to the underlying `PKCanvasView`'s `isDrawingEnabled` property if possible (ie, when running on iOS 18+)
2. properly handle changes made to the `drawing` Binding, thereby allowing external code to e.g. reset the drawing while the CanvasView is presented.

## :gear: Release Notes
- CanvasView now supports the `.disabled(_:)` view modifier
- CanvasView now updates itself if the `drawing` Binding was written to externally.


## :books: Documentation
There is no explicit documentation for this behaviour, since it's reasonable to expect one to assume that the `.disabled(_:)` modifier is how one would disable the view.


## :white_check_mark: Testing
We have a new test that checks that the modifier is properly taken into account.


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
