### PR TITLE
ShareSheet API

### DIFF
--- a/Sources/SpeziViews/SpeziViews.docc/SpeziViews.md
+++ b/Sources/SpeziViews/SpeziViews.docc/SpeziViews.md
@@ -70,6 +70,7 @@ Default layouts and utilities to automatically adapt your view layouts to dynami
 - ``DismissButton``
 - ``CaseIterablePicker``
 - ``OptionSetPicker``
+- ``SwiftUICore/View/shareSheet(items:)``
 
 ### Managed Navigation
 

--- a/Sources/SpeziViews/Views/Sharing/ShareSheetInput.swift
+++ b/Sources/SpeziViews/Views/Sharing/ShareSheetInput.swift
@@ -1,0 +1,129 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+// swiftlint:disable file_types_order
+
+import Foundation
+import class PDFKit.PDFDocument
+
+
+/// Marker protocol that indicates that a type can be directly passed into a `UIActivityViewController`, without having to go through a `NSItemProvider`.
+@_marker
+public protocol HasDirectUIActivityViewControllerSupport {}
+extension String: HasDirectUIActivityViewControllerSupport {}
+extension URL: HasDirectUIActivityViewControllerSupport {}
+
+
+/// An Array of ``ShareSheetInput`` values, providing `Identifiable` conformance for SwiftUI integration.
+struct CombinedShareSheetInput: Identifiable, Equatable {
+    let inputs: [ShareSheetInput]
+    let id: AnyHashable
+    
+    var isEmpty: Bool {
+        inputs.isEmpty
+    }
+    
+    init(inputs: [ShareSheetInput]) {
+        self.inputs = inputs
+        self.id = AnyHashable(inputs.map(\.id))
+    }
+    
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+
+/// A value that is included when presenting a share sheet
+///
+/// ## Topics
+/// ### Initializers
+/// - ``init(_:)-(Input)``
+/// - ``init(_:id:)``
+/// - ``init(_:)-(NSItemProviderWriting)``
+/// - ``init(_:)-(T)``
+/// - ``init(_:)-(PDFDocument)``
+/// - ``init(verbatim:id:)``
+///
+/// ### Supporting Types
+/// - ``HasDirectUIActivityViewControllerSupport``
+public struct ShareSheetInput {
+    enum RepresentationForSharing {
+        case itemProvider(NSItemProvider)
+        case other(Any)
+    }
+    
+    let id: AnyHashable
+    let representationForSharing: Any
+    
+    private init(id: AnyHashable, itemProvider: NSItemProvider) {
+        self.id = id
+        self.representationForSharing = itemProvider
+    }
+    
+    private init(id: AnyHashable, representationForSharing: Any) {
+        self.id = id
+        self.representationForSharing = representationForSharing
+    }
+}
+
+
+extension ShareSheetInput {
+    /// Creates a new `ShareSheetInput`.
+    public init<Input>(_ input: Input) where Input: HasDirectUIActivityViewControllerSupport & Hashable {
+        self.init(input, id: \.self)
+    }
+    
+    /// Creates a new `ShareSheetInput`.
+    public init<Input>(_ input: Input, id: (Input) -> some Hashable) where Input: HasDirectUIActivityViewControllerSupport {
+        self.init(id: AnyHashable(id(input)), representationForSharing: input)
+    }
+    
+    /// Creates a new `ShareSheetInput`, for sharing an `NSItemProviderWriting`-conforming value
+    public init(_ input: some NSItemProviderWriting) {
+        self.init(
+            id: ObjectIdentifier(input),
+            itemProvider: NSItemProvider(object: input)
+        )
+    }
+    
+    /// Creates a new `ShareSheetInput`, for sharing an `NSItemProviderWriting`-conforming value
+    @_disfavoredOverload
+    public init<T>(_ input: T) where T: _ObjectiveCBridgeable, T._ObjectiveCType: NSItemProviderWriting {
+        self.init(input._bridgeToObjectiveC())
+    }
+    
+    /// Creates a new `ShareSheetInput`, for sharing a `PDFDocument`
+    public init(_ input: PDFDocument) {
+        self.init(ShareableRepresentation(pdf: input))
+    }
+    
+    /// Creates a new `ShareSheetInput`.
+    ///
+    /// This initializer will cause the `input` value to get directly passe on to `UIActivityViewController` on iOS and `NSSharingServicePicker` on macOS,
+    /// without performing any processing or transformation based on the specific input type.
+    ///
+    /// - Note: Only use this initializer if you know for a fact that `Input` is compatible with the system share sheet.
+    public init<Input>(verbatim input: Input, id: (Input) -> some Hashable) {
+        self.init(id: id(input), representationForSharing: input)
+    }
+}
+
+
+extension Hashable {
+    fileprivate var asAnyHashable: AnyHashable {
+        AnyHashable(self)
+    }
+}
+
+extension AnyHashable {
+    @_disfavoredOverload
+    init(_ base: any Hashable) {
+        self = base.asAnyHashable
+    }
+}

--- a/Sources/SpeziViews/Views/Sharing/ShareableRepresentation.swift
+++ b/Sources/SpeziViews/Views/Sharing/ShareableRepresentation.swift
@@ -1,0 +1,96 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import OSLog
+import PDFKit
+import UniformTypeIdentifiers
+
+
+final class ShareableRepresentation: NSObject {
+    private static let logger = Logger(subsystem: "edu.stanford.Spezi.SpeziViews.ShareableRepresentation", category: "UI")
+    
+    let value: Any
+    private let cleanupHandler: () throws -> Void
+    
+    private init(value: Any, cleanupHandler: @escaping () throws -> Void = {}) {
+        self.value = value
+        self.cleanupHandler = cleanupHandler
+        super.init()
+    }
+    
+    convenience init(processing input: Any) {
+        if let pdf = input as? PDFKit.PDFDocument {
+            self.init(pdf: pdf)
+        } else {
+            // let's just give it a try
+            self.init(value: input)
+        }
+    }
+    
+    convenience init(pdf: PDFKit.PDFDocument) {
+        let title = pdf.documentAttributes?[PDFDocumentAttribute.titleAttribute] as? String ?? "file"
+        let url = Self.tmpUrl(for: title, conformingTo: .pdf)
+        if let data = pdf.dataRepresentation(), (try? data.write(to: url)) != nil {
+            // success
+        } else {
+            Self.logger.error("Failed to write PDF to disk")
+        }
+        self.init(value: url) {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+    
+    deinit {
+        do {
+            try cleanupHandler()
+        } catch {
+            Self.logger.error("Error in cleanup handler: \(error)")
+        }
+    }
+}
+
+
+extension ShareableRepresentation {
+    private static func tmpUrl(for filename: String, conformingTo type: UTType) -> URL {
+        let fileManager = FileManager.default
+        let baseUrl = fileManager.temporaryDirectory.appending(component: "SpeziShareSheet", directoryHint: .isDirectory)
+        let fileUrl = baseUrl.appendingPathComponent(filename, conformingTo: type)
+        try? fileManager.createDirectory(at: baseUrl, withIntermediateDirectories: true)
+        return fileUrl
+    }
+}
+
+
+extension ShareableRepresentation: NSItemProviderWriting {
+    static var writableTypeIdentifiersForItemProvider: [String] {
+        []
+    }
+    
+    var writableTypeIdentifiersForItemProvider: [String] {
+        if let value = value as? any NSItemProviderWriting {
+            return value.writableTypeIdentifiersForItemProvider ?? type(of: value).writableTypeIdentifiersForItemProvider
+        } else {
+            Self.logger.error("Value of type '\(type(of: self.value))' doesn't conform to \((any NSItemProviderWriting).self)!")
+            return []
+        }
+    }
+    
+    func loadData(
+        withTypeIdentifier typeIdentifier: String,
+        forItemProviderCompletionHandler completionHandler: @escaping @Sendable (Data?, (any Error)?) -> Void
+    ) -> Progress? {
+        if let value = value as? any NSItemProviderWriting {
+            return value.loadData(withTypeIdentifier: typeIdentifier, forItemProviderCompletionHandler: completionHandler)
+        } else {
+            Self.logger.error("Value of type '\(type(of: self.value))' doesn't conform to \((any NSItemProviderWriting).self)!")
+            completionHandler(nil, NSError(domain: "edu.stanford.SpeziViews", code: 0))
+            return nil
+        }
+    }
+}

--- a/Tests/UITests/TestApp/Examples/SkeletonLoadingExample.swift
+++ b/Tests/UITests/TestApp/Examples/SkeletonLoadingExample.swift
@@ -14,7 +14,11 @@ struct SkeletonLoadingExample: View {
     var body: some View {
         VStack {
             RoundedRectangle(cornerRadius: 10)
+            #if canImport(UIKit)
                 .fill(Color(UIColor.systemGray4))
+            #elseif canImport(AppKit)
+                .fill(Color(NSColor.systemGray))
+            #endif
                 .frame(height: 100)
                 .skeletonLoading(replicationCount: 5, repeatInterval: 1.5, spacing: 16)
             Spacer()

--- a/Tests/UITests/TestApp/Localizable.xcstrings
+++ b/Tests/UITests/TestApp/Localizable.xcstrings
@@ -229,6 +229,27 @@
     "Selection" : {
 
     },
+    "Share PDF" : {
+
+    },
+    "Share PDF via Data" : {
+
+    },
+    "Share PDF via URL" : {
+
+    },
+    "Share Sheet" : {
+
+    },
+    "Share Text" : {
+
+    },
+    "Share UIImage" : {
+
+    },
+    "Share UIImage via URL" : {
+
+    },
     "Show Tool Picker" : {
 
     },

--- a/Tests/UITests/TestApp/Platform.swift
+++ b/Tests/UITests/TestApp/Platform.swift
@@ -1,0 +1,17 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+#if canImport(UIKit)
+import UIKit
+typealias UINSColor = UIColor
+typealias UINSImage = UIImage
+#elseif canImport(AppKit)
+import AppKit
+typealias UINSColor = NSColor
+typealias UINSImage = NSImage
+#endif

--- a/Tests/UITests/TestApp/TestApp.entitlements.license
+++ b/Tests/UITests/TestApp/TestApp.entitlements.license
@@ -1,5 +1,0 @@
-This source file is part of the Stanford Spezi open-source project
-
-SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
-
-SPDX-License-Identifier: MIT

--- a/Tests/UITests/TestApp/ViewsTests/CaseIterablePickerTests.swift
+++ b/Tests/UITests/TestApp/ViewsTests/CaseIterablePickerTests.swift
@@ -72,7 +72,9 @@ struct CaseIterablePickerTests: View {
             OptionSetPicker("Inline Picker", selection: $optionSetMenu, style: .inline)
         }
             .navigationTitle("Picker")
+        #if !os(macOS)
             .navigationBarTitleDisplayMode(.inline)
+        #endif
     }
 }
 

--- a/Tests/UITests/TestApp/ViewsTests/ShareSheetTests.swift
+++ b/Tests/UITests/TestApp/ViewsTests/ShareSheetTests.swift
@@ -1,0 +1,65 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import PDFKit
+import SpeziViews
+import SwiftUI
+
+
+struct ShareSheetTests: View {
+    @State private var itemsToShare: [ShareSheetInput] = []
+    
+    var body: some View {
+        Form { // swiftlint:disable:this closure_body_length
+            Section {
+                Button("Share UIImage") {
+                    guard let url = Bundle.main.url(forResource: "jellybeans_USC-SIPI", withExtension: "tiff"),
+                          let image = UINSImage(contentsOfFile: url.path) else {
+                        return
+                    }
+                    itemsToShare = [ShareSheetInput(image)]
+                }
+                Button("Share UIImage via URL") {
+                    guard let url = Bundle.main.url(forResource: "jellybeans_USC-SIPI", withExtension: "tiff") else {
+                        return
+                    }
+                    itemsToShare = [ShareSheetInput(url)]
+                }
+            }
+            Section {
+                Button("Share PDF") {
+                    guard let url = Bundle.main.url(forResource: "pepsi-arnell-021109", withExtension: "pdf"),
+                          let pdf = PDFDocument(url: url) else {
+                        return
+                    }
+                    itemsToShare = [ShareSheetInput(pdf)]
+                }
+                Button("Share PDF via Data") {
+                    guard let url = Bundle.main.url(forResource: "pepsi-arnell-021109", withExtension: "pdf"),
+                          let pdf = PDFDocument(url: url),
+                          let data = pdf.dataRepresentation() else {
+                        return
+                    }
+                    itemsToShare = [ShareSheetInput(verbatim: data, id: \.self)]
+                }
+                Button("Share PDF via URL") {
+                    guard let url = Bundle.main.url(forResource: "pepsi-arnell-021109", withExtension: "pdf") else {
+                        return
+                    }
+                    itemsToShare = [ShareSheetInput(url)]
+                }
+            }
+            Section {
+                Button("Share Text") {
+                    itemsToShare = [ShareSheetInput("Hello Spezi!")]
+                }
+            }
+        }
+        .shareSheet(items: $itemsToShare)
+    }
+}

--- a/Tests/UITests/TestApp/ViewsTests/SpeziViewsTests.swift
+++ b/Tests/UITests/TestApp/ViewsTests/SpeziViewsTests.swift
@@ -31,6 +31,7 @@ enum SpeziViewsTests: String, TestAppTests {
     case listRow = "List Row"
     case managedViewUpdate = "Managed View Update"
     case caseIterablePicker = "Picker"
+    case shareSheet = "Share Sheet"
 
     
     #if canImport(PencilKit) && !os(macOS)
@@ -180,6 +181,8 @@ enum SpeziViewsTests: String, TestAppTests {
             ManagedViewStateTests()
         case .caseIterablePicker:
             CaseIterablePickerTests()
+        case .shareSheet:
+            ShareSheetTests()
         }
     }
 }

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -7,17 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2F6D139A28F5F386007C25D6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2F6D139928F5F386007C25D6 /* Assets.xcassets */; };
-		2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA7382B290ADFAA007ACEB9 /* TestApp.swift */; };
 		2FA9486F29DE91A30081C086 /* SpeziViews in Frameworks */ = {isa = PBXBuildFile; productRef = 2FA9486E29DE91A30081C086 /* SpeziViews */; };
-		2FB099B82A8AD25300B20952 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 2FB099B72A8AD25100B20952 /* Localizable.xcstrings */; };
-		806F2C072DFF5D7B00F21D03 /* Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806F2C062DFF5D7B00F21D03 /* Platform.swift */; };
 		977CF55C2AD2B92C006D9B54 /* XCTestApp in Frameworks */ = {isa = PBXBuildFile; productRef = 977CF55B2AD2B92C006D9B54 /* XCTestApp */; };
 		A95B6E652AF4298500919504 /* SpeziPersonalInfo in Frameworks */ = {isa = PBXBuildFile; productRef = A95B6E642AF4298500919504 /* SpeziPersonalInfo */; };
 		A963ACB02AF4692500D745F2 /* SpeziValidation in Frameworks */ = {isa = PBXBuildFile; productRef = A963ACAF2AF4692500D745F2 /* SpeziValidation */; };
 		A9BA82B42C29FF7C00472FF3 /* Spezi in Frameworks */ = {isa = PBXBuildFile; productRef = A9BA82B32C29FF7C00472FF3 /* Spezi */; };
 		A9F9C4692AF2B9DD001122DD /* XCTestExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 977CF55D2AD2B92C006D9B54 /* XCTestExtensions */; };
-		A9FBAE952AF445B6001E4AF1 /* SpeziViewsTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FBAE942AF445B6001E4AF1 /* SpeziViewsTargetsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -33,39 +28,19 @@
 /* Begin PBXFileReference section */
 		2F61BDC129DD023E00D71D33 /* SpeziViews */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = SpeziViews; path = ../..; sourceTree = "<group>"; };
 		2F6D139228F5F384007C25D6 /* TestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		2F6D139928F5F386007C25D6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		2FA7382B290ADFAA007ACEB9 /* TestApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
 		2FB0758A299DDB9000C0B37F /* TestApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestApp.xctestplan; sourceTree = "<group>"; };
-		2FB099B72A8AD25100B20952 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
-		806F2C062DFF5D7B00F21D03 /* Platform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Platform.swift; sourceTree = "<group>"; };
-		A9FBAE942AF445B6001E4AF1 /* SpeziViewsTargetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeziViewsTargetsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		80547A3C2D9817A4008C13FF /* ViewsTests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = ViewsTests;
-			sourceTree = "<group>";
-		};
-		80547A502D9817AA008C13FF /* Examples */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = Examples;
-			sourceTree = "<group>";
-		};
-		80547A5B2D9817AA008C13FF /* ValidationTests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = ValidationTests;
-			sourceTree = "<group>";
-		};
-		80547A622D9817AA008C13FF /* PersonalInfoTests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = PersonalInfoTests;
-			sourceTree = "<group>";
-		};
 		80547A9B2D988067008C13FF /* TestAppUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = TestAppUITests;
+			sourceTree = "<group>";
+		};
+		806F2C2D2DFF6A1300F21D03 /* TestApp */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = TestApp;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -99,7 +74,7 @@
 			children = (
 				2FB0758A299DDB9000C0B37F /* TestApp.xctestplan */,
 				2F61BDC129DD023E00D71D33 /* SpeziViews */,
-				2F6D139428F5F384007C25D6 /* TestApp */,
+				806F2C2D2DFF6A1300F21D03 /* TestApp */,
 				80547A9B2D988067008C13FF /* TestAppUITests */,
 				2F6D139328F5F384007C25D6 /* Products */,
 				2F6D13C228F5F3BE007C25D6 /* Frameworks */,
@@ -113,22 +88,6 @@
 				2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		2F6D139428F5F384007C25D6 /* TestApp */ = {
-			isa = PBXGroup;
-			children = (
-				A9FBAE942AF445B6001E4AF1 /* SpeziViewsTargetsTests.swift */,
-				2FA7382B290ADFAA007ACEB9 /* TestApp.swift */,
-				806F2C062DFF5D7B00F21D03 /* Platform.swift */,
-				2F6D139928F5F386007C25D6 /* Assets.xcassets */,
-				2FB099B72A8AD25100B20952 /* Localizable.xcstrings */,
-				80547A502D9817AA008C13FF /* Examples */,
-				80547A622D9817AA008C13FF /* PersonalInfoTests */,
-				80547A5B2D9817AA008C13FF /* ValidationTests */,
-				80547A3C2D9817A4008C13FF /* ViewsTests */,
-			);
-			path = TestApp;
 			sourceTree = "<group>";
 		};
 		2F6D13C228F5F3BE007C25D6 /* Frameworks */ = {
@@ -154,10 +113,7 @@
 			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
-				80547A3C2D9817A4008C13FF /* ViewsTests */,
-				80547A502D9817AA008C13FF /* Examples */,
-				80547A5B2D9817AA008C13FF /* ValidationTests */,
-				80547A622D9817AA008C13FF /* PersonalInfoTests */,
+				806F2C2D2DFF6A1300F21D03 /* TestApp */,
 			);
 			name = TestApp;
 			packageProductDependencies = (
@@ -243,8 +199,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2FB099B82A8AD25300B20952 /* Localizable.xcstrings in Resources */,
-				2F6D139A28F5F386007C25D6 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -262,9 +216,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A9FBAE952AF445B6001E4AF1 /* SpeziViewsTargetsTests.swift in Sources */,
-				806F2C072DFF5D7B00F21D03 /* Platform.swift in Sources */,
-				2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA7382B290ADFAA007ACEB9 /* TestApp.swift */; };
 		2FA9486F29DE91A30081C086 /* SpeziViews in Frameworks */ = {isa = PBXBuildFile; productRef = 2FA9486E29DE91A30081C086 /* SpeziViews */; };
 		2FB099B82A8AD25300B20952 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 2FB099B72A8AD25100B20952 /* Localizable.xcstrings */; };
+		806F2C072DFF5D7B00F21D03 /* Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806F2C062DFF5D7B00F21D03 /* Platform.swift */; };
 		977CF55C2AD2B92C006D9B54 /* XCTestApp in Frameworks */ = {isa = PBXBuildFile; productRef = 977CF55B2AD2B92C006D9B54 /* XCTestApp */; };
 		A95B6E652AF4298500919504 /* SpeziPersonalInfo in Frameworks */ = {isa = PBXBuildFile; productRef = A95B6E642AF4298500919504 /* SpeziPersonalInfo */; };
 		A963ACB02AF4692500D745F2 /* SpeziValidation in Frameworks */ = {isa = PBXBuildFile; productRef = A963ACAF2AF4692500D745F2 /* SpeziValidation */; };
@@ -37,6 +38,7 @@
 		2FA7382B290ADFAA007ACEB9 /* TestApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
 		2FB0758A299DDB9000C0B37F /* TestApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestApp.xctestplan; sourceTree = "<group>"; };
 		2FB099B72A8AD25100B20952 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		806F2C062DFF5D7B00F21D03 /* Platform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Platform.swift; sourceTree = "<group>"; };
 		A9FBAE942AF445B6001E4AF1 /* SpeziViewsTargetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeziViewsTargetsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -118,6 +120,7 @@
 			children = (
 				A9FBAE942AF445B6001E4AF1 /* SpeziViewsTargetsTests.swift */,
 				2FA7382B290ADFAA007ACEB9 /* TestApp.swift */,
+				806F2C062DFF5D7B00F21D03 /* Platform.swift */,
 				2F6D139928F5F386007C25D6 /* Assets.xcassets */,
 				2FB099B72A8AD25100B20952 /* Localizable.xcstrings */,
 				80547A502D9817AA008C13FF /* Examples */,
@@ -260,6 +263,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A9FBAE952AF445B6001E4AF1 /* SpeziViewsTargetsTests.swift in Sources */,
+				806F2C072DFF5D7B00F21D03 /* Platform.swift in Sources */,
 				2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
# ShareSheet API

## :recycle: Current situation & Problem
SwiftUI doesn't (yet?) have a native integration point for presenting the system share sheet.
This PR adds a `shareSheet(items: Binding<[ShareSheetInput]>)` modifier, which presents a platform-appropriate system share sheet if the value in the binding changes to a non-empty array.

On iOS, we present a `UIActivityViewController`, whereas on macOS we use the `NSSharingServicePicker` API.

Note: This implementation is based on code that currently still is in SpeziOnboarding, refactoring that code (which is specific for sharing signed cosent PDFs) into a generic API that can handle a range of different input types.


## :gear: Release Notes
- added `View.shareSheet(items:)` modifier


## :books: Documentation
The new code is documented.


## :white_check_mark: Testing
*todo*


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
