### PR TITLE
`nextStep() -> Bool`

### DIFF
--- a/Sources/SpeziViews/Views/ManagedNavigationStack/ManagedNavigationStack+Path.swift
+++ b/Sources/SpeziViews/Views/ManagedNavigationStack/ManagedNavigationStack+Path.swift
@@ -246,13 +246,17 @@ extension ManagedNavigationStack.Path {
     /// The tracking of the current state of the navigation flow is done fully automatic by the ``ManagedNavigationStack/Path``.
     ///
     /// After all navigation steps have been shown, the injected `isComplete` binding is set to `true` indicating that the navigation flow is completed.
-    public func nextStep() {
+    ///
+    /// - returns: A `Bool` indicating whether the navigation was successful; will be `false` if the ``ManagedNavigationStack/Path`` is already at its end and there are no further steps.
+    @discardableResult
+    public func nextStep() -> Bool {
         guard let currentStepIndex = steps.elements.keys.firstIndex(where: { $0 == currentStep }),
               currentStepIndex + 1 < steps.elements.count else {
             isComplete?.wrappedValue = true
-            return
+            return false
         }
         pushStep(identifiedBy: steps.elements.keys[currentStepIndex + 1])
+        return true
     }
     
     /// Modifies the navigation path to move to the next navigation step identified by the specified value, and also add all steps inbetween.


### PR DESCRIPTION
# `nextStep() -> Bool`

## :recycle: Current situation & Problem
changes the `ManagedNavigationStack.Path`'s `nextStep()` function to return a `Bool` that indicates whether the operation was successful.

since the function used to return `Void`, and now has the `@discardableResult` attribute, this change will not impact compilation of existing uses at all.

## :gear: Release Notes
- `ManagedNavigationStep.Path/nextStep()` now returns a `Bool`


## :books: Documentation
the behaviour is documented


## :white_check_mark: Testing
n/a


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
