### PR TITLE
`DismissButton`: restore pre-swift6.2 compatibility

### DIFF
--- a/Sources/SpeziViews/Views/Button/DismissButton.swift
+++ b/Sources/SpeziViews/Views/Button/DismissButton.swift
@@ -14,6 +14,7 @@ public struct DismissButton: View {
     @Environment(\.dismiss) private var dismiss
 
     public var body: some View {
+        #if swift(>=6.2)
         #if os(visionOS) || os(tvOS) || os(macOS)
         if #available(visionOS 26, tvOS 26, macOS 26, *) {
             Button(role: .close) {
@@ -30,29 +31,37 @@ public struct DismissButton: View {
                 dismiss()
             }
         } else {
-            Button {
-                dismiss()
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 10, weight: .bold, design: .rounded))
-                    #if !os(watchOS)
-                    .foregroundStyle(.secondary)
-                    #endif
-                    .background {
-                        Circle()
-                            #if os(iOS)
-                            .fill(Color(uiColor: .secondarySystemBackground))
-                            #elseif os(watchOS)
-                            .fill(Color(uiColor: .darkGray))
-                            #endif
-                            .frame(width: 25, height: 25)
-                    }
-                    .frame(width: 27, height: 27) // make the tap-able button region slightly larger
-            }
-            .accessibilityLabel("Dismiss")
-            .buttonStyle(.plain)
+            fallbackButton
         }
         #endif
+        #else
+        fallbackButton
+        #endif
+    }
+    
+    
+    @ViewBuilder private var fallbackButton: some View {
+        Button {
+            dismiss()
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: 10, weight: .bold, design: .rounded))
+                #if !os(watchOS)
+                .foregroundStyle(.secondary)
+                #endif
+                .background {
+                    Circle()
+                        #if os(iOS)
+                        .fill(Color(uiColor: .secondarySystemBackground))
+                        #elseif os(watchOS)
+                        .fill(Color(uiColor: .darkGray))
+                        #endif
+                        .frame(width: 25, height: 25)
+                }
+                .frame(width: 27, height: 27) // make the tap-able button region slightly larger
+        }
+        .accessibilityLabel("Dismiss")
+        .buttonStyle(.plain)
     }
 
     public init() {}


### PR DESCRIPTION
# `DismissButton`: restore pre-swift6.2 compatibility

## :recycle: Current situation & Problem
#75 updated the `DismissButton` to use new types and overloads from the iOS 26 SDK, but did so without updating the Package.swift file's Swift version requirement, as a result breaking the package on Xcode 16.x


## :gear: Release Notes
- `DismissButton`: restore pre-swift6.2 compatibility


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
