### PR TITLE
fix AsyncButton in 26.1 toolbars

### DIFF
--- a/Sources/SpeziValidation/ValidationEngine.swift
+++ b/Sources/SpeziValidation/ValidationEngine.swift
@@ -37,7 +37,7 @@ public final class ValidationEngine: Identifiable {
 
 
     /// Unique identifier for this validation engine.
-    public nonisolated var id: ObjectIdentifier {
+    nonisolated public var id: ObjectIdentifier {
         ObjectIdentifier(self)
     }
 

--- a/Sources/SpeziValidation/ValidationState/CapturedValidationState.swift
+++ b/Sources/SpeziValidation/ValidationState/CapturedValidationState.swift
@@ -18,8 +18,8 @@ import SwiftUI
 @dynamicMemberLookup
 @MainActor
 public struct CapturedValidationState {
-    private nonisolated let engine: ValidationEngine
-    private nonisolated let input: String
+    nonisolated private let engine: ValidationEngine
+    nonisolated private let input: String
     private let focusState: FocusState<Bool>.Binding
 
     init(engine: ValidationEngine, input: String, focus focusState: FocusState<Bool>.Binding) {
@@ -48,7 +48,7 @@ public struct CapturedValidationState {
 
 
 extension CapturedValidationState: Equatable, Sendable {
-    public static nonisolated func == (lhs: CapturedValidationState, rhs: CapturedValidationState) -> Bool {
+    nonisolated public static func == (lhs: CapturedValidationState, rhs: CapturedValidationState) -> Bool {
         lhs.engine === rhs.engine && lhs.input == rhs.input
     }
 }

--- a/Tests/UITests/TestApp/Localizable.xcstrings
+++ b/Tests/UITests/TestApp/Localizable.xcstrings
@@ -25,6 +25,12 @@
     "Append Custom View" : {
 
     },
+    "AsyncButton Toolbar Behaviour" : {
+
+    },
+    "AsyncButtonInToolbar" : {
+
+    },
     "Buy" : {
 
     },
@@ -75,6 +81,9 @@
 
     },
     "Did Draw Anything: %@" : {
+
+    },
+    "Did tap" : {
 
     },
     "Done" : {
@@ -208,6 +217,9 @@
     "Option Set" : {
 
     },
+    "Other" : {
+
+    },
     "Password" : {
 
     },
@@ -329,6 +341,9 @@
 
     },
     "Tap Me ;)" : {
+
+    },
+    "Tap Me!" : {
 
     },
     "Targets" : {

--- a/Tests/UITests/TestApp/SpeziViewsTargetsTests.swift
+++ b/Tests/UITests/TestApp/SpeziViewsTargetsTests.swift
@@ -17,6 +17,7 @@ struct SpeziViewsTargetsTests: View {
     @State var presentingSpeziPersonalInfo = false
     @State var presentingSpeziValidation = false
     @State var presentingManagedNavigationStack = false
+    @State var presentingToolbarAsyncButtonSheet = false
 
 #if os(macOS)
     @MainActor
@@ -70,6 +71,12 @@ struct SpeziViewsTargetsTests: View {
                     CanvasTestView()
                 }
                 #endif
+                
+                Section("Other") {
+                    Button("AsyncButton Toolbar Behaviour") {
+                        presentingToolbarAsyncButtonSheet = true
+                    }
+                }
 
                 Section {
                     NavigationLink("ViewState") {
@@ -93,45 +100,48 @@ struct SpeziViewsTargetsTests: View {
                     Text("Example Views to take screenshots for SpeziViews")
                 }
             }
-                .navigationTitle("Targets")
-                .toolbar {
-#if os(macOS)
-                    ToolbarItem(placement: .automatic) {
-                        Toggle("Flip Layout Direction", isOn: $enableFlippedLayoutDirection)
-                    }
-#else
-                    ToolbarItem(placement: .topBarTrailing) {
-                        Toggle("Flip Layout Direction", isOn: $enableFlippedLayoutDirection)
-                    }
-#endif
+            .navigationTitle("Targets")
+            .toolbar {
+                #if os(macOS)
+                ToolbarItem(placement: .automatic) {
+                    Toggle("Flip Layout Direction", isOn: $enableFlippedLayoutDirection)
                 }
+                #else
+                ToolbarItem(placement: .topBarTrailing) {
+                    Toggle("Flip Layout Direction", isOn: $enableFlippedLayoutDirection)
+                }
+                #endif
+            }
         }
         .environment(\.layoutDirection, effectiveLayoutDirection)
-            .sheet(isPresented: $presentingSpeziViews) {
-                TestAppTestsView<SpeziViewsTests>(showCloseButton: true)
-                    .environment(\.layoutDirection, effectiveLayoutDirection)
+        .sheet(isPresented: $presentingSpeziViews) {
+            TestAppTestsView<SpeziViewsTests>(showCloseButton: true)
+                .environment(\.layoutDirection, effectiveLayoutDirection)
 #if os(macOS)
-                    .frame(minWidth: idealWidth, minHeight: idealHeight)
+                .frame(minWidth: idealWidth, minHeight: idealHeight)
 #endif
-            }
-            .sheet(isPresented: $presentingSpeziPersonalInfo) {
-                TestAppTestsView<SpeziPersonalInfoTests>(showCloseButton: true)
+        }
+        .sheet(isPresented: $presentingSpeziPersonalInfo) {
+            TestAppTestsView<SpeziPersonalInfoTests>(showCloseButton: true)
 #if os(macOS)
-                    .frame(minWidth: idealWidth, minHeight: idealHeight)
+                .frame(minWidth: idealWidth, minHeight: idealHeight)
 #endif
-            }
-            .sheet(isPresented: $presentingSpeziValidation) {
-                TestAppTestsView<SpeziValidationTests>(showCloseButton: true)
+        }
+        .sheet(isPresented: $presentingSpeziValidation) {
+            TestAppTestsView<SpeziValidationTests>(showCloseButton: true)
 #if os(macOS)
-                    .frame(minWidth: idealWidth, minHeight: idealHeight)
+                .frame(minWidth: idealWidth, minHeight: idealHeight)
 #endif
-            }
-            .sheet(isPresented: $presentingManagedNavigationStack) {
-                ManagedNavigationStackTestView()
+        }
+        .sheet(isPresented: $presentingManagedNavigationStack) {
+            ManagedNavigationStackTestView()
 #if os(macOS)
-                    .frame(minWidth: idealWidth, minHeight: idealHeight)
+                .frame(minWidth: idealWidth, minHeight: idealHeight)
 #endif
-            }
+        }
+        .sheet(isPresented: $presentingToolbarAsyncButtonSheet) {
+            AsyncButtonToolbarTestSheet()
+        }
     }
 }
 

--- a/Tests/UITests/TestApp/ViewsTests/AsyncButtonToolbarTest.swift
+++ b/Tests/UITests/TestApp/ViewsTests/AsyncButtonToolbarTest.swift
@@ -1,0 +1,34 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SpeziViews
+import SwiftUI
+
+
+struct AsyncButtonToolbarTestSheet: View {
+    @State private var didTap = false
+    
+    var body: some View {
+        NavigationStack {
+            Form {
+                LabeledContent("Did tap", value: didTap.description)
+            }
+            .navigationTitle("AsyncButtonInToolbar")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    DismissButton()
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    AsyncButton("Tap Me!") {
+                        didTap = true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tests/UITests/TestApp/ViewsTests/ButtonTestView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/ButtonTestView.swift
@@ -55,7 +55,7 @@ struct ButtonTestView: View {
     @State private var presentedText = "Hello"
 
     var body: some View {
-        List { // swiftlint:disable:this closure_body_length
+        Form { // swiftlint:disable:this closure_body_length
             if showCompleted {
                 Section {
                     Text("Action executed")

--- a/Tests/UITests/TestAppUITests/SpeziViews/ViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/SpeziViews/ViewsTests.swift
@@ -212,6 +212,17 @@ final class ViewsTests: XCTestCase {
 
         XCTAssert(app.staticTexts["Captured Hello World"].waitForExistence(timeout: 0.5))
     }
+    
+    @MainActor
+    func testAsyncButtonInToolbar() throws {
+        let app = XCUIApplication()
+        app.launch()
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
+        app.buttons["AsyncButton Toolbar Behaviour"].tap()
+        XCTAssert(app.staticTexts["Did tap, false"].waitForExistence(timeout: 2))
+        app.navigationBars["AsyncButtonInToolbar"].buttons["Tap Me!"].tap()
+        XCTAssert(app.staticTexts["Did tap, true"].waitForExistence(timeout: 2))
+    }
 
     @MainActor
     func testListRowAccessibility() throws {


### PR DESCRIPTION
# fix AsyncButton in 26.1 toolbars

## :recycle: Current situation & Problem
iOS 26.1 breaks `AsyncButton`s in toolbars (see #80)


## :gear: Release Notes
- fixes #80


## :books: Documentation
n/a


## :white_check_mark: Testing
we have a regression test


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
