### PR TITLE
DismissButton accessibility identifier

### DIFF
--- a/Sources/SpeziViews/Views/Button/DismissButton.swift
+++ b/Sources/SpeziViews/Views/Button/DismissButton.swift
@@ -13,7 +13,14 @@ import SwiftUI
 public struct DismissButton: View {
     @Environment(\.dismiss) private var dismiss
 
+    @_documentation(visibility: internal)
     public var body: some View {
+        button
+            .accessibilityIdentifier("Close")
+    }
+    
+    
+    @ViewBuilder private var button: some View {
 #if swift(>=6.2)
     #if os(visionOS) || os(tvOS) || os(macOS)
         if #available(visionOS 26, tvOS 26, macOS 26, *) {
@@ -40,7 +47,7 @@ public struct DismissButton: View {
     }
     
     
-    @ViewBuilder private var fallbackButton: some View {
+    private var fallbackButton: some View {
 #if os(visionOS) || os(tvOS) || os(macOS)
         Button("Dismiss", systemImage: "xmark") {
             dismiss()


### PR DESCRIPTION
# DismissButton accessibility identifier

## :recycle: Current situation & Problem
the `DismissButton` currently does not have an accessibility identifier (it does have a label), which makes it difficult to work with it in a non-english UI test.


## :gear: Release Notes
- DismissButton now has a fixed "Close" accessibility identifier.


## :books: Documentation
n/a


## :white_check_mark: Testing
the changes in this PR are intended to make UI testing in other packages/apps easier.


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
