### PR TITLE
CanvasView performance improvements

### DIFF
--- a/Sources/SpeziViews/Views/Drawing/CanvasView.swift
+++ b/Sources/SpeziViews/Views/Drawing/CanvasView.swift
@@ -161,22 +161,22 @@ extension CanvasView {
             }
             
             func canvasViewDrawingDidChange(_ pkCanvasView: PKCanvasView) {
-                Task { @MainActor in
-                    parent.drawing = pkCanvasView.drawing
+                let oldDrawing = parent.drawing
+                let newDrawing = pkCanvasView.drawing
+                guard oldDrawing != newDrawing && !(oldDrawing.isEmpty && newDrawing.isEmpty) else {
+                    // empty drawings don't necessarily compare equal to each other (FB22283461)
+                    return
                 }
+                parent.drawing = newDrawing
             }
             
             func toolPickerSelectedToolDidChange(_ toolPicker: PKToolPicker) {
-                Task { @MainActor in
-                    handleToolDidChange(toolPicker)
-                }
+                handleToolDidChange(toolPicker)
             }
             
             @available(iOS 18.0, visionOS 2.0, *)
             func toolPickerSelectedToolItemDidChange(_ toolPicker: PKToolPicker) {
-                Task { @MainActor in
-                    handleToolDidChange(toolPicker)
-                }
+                handleToolDidChange(toolPicker)
             }
             
             @MainActor

--- a/Sources/SpeziViews/Views/Drawing/PencilKit+Utils.swift
+++ b/Sources/SpeziViews/Views/Drawing/PencilKit+Utils.swift
@@ -1,0 +1,34 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+#if canImport(PencilKit)
+import PencilKit
+
+extension PKDrawing: @retroactive Hashable {
+    public func hash(into hasher: inout Hasher) {
+        if #available(iOS 18, *) {
+            hasher.combine(self.bounds)
+        } else {
+            let bounds = self.bounds
+            hasher.combine(bounds.origin.x)
+            hasher.combine(bounds.origin.y)
+            hasher.combine(bounds.size.width)
+            hasher.combine(bounds.size.height)
+        }
+        hasher.combine(self.strokes.count)
+    }
+}
+
+extension PKDrawing {
+    /// Whether the drawing contains no strokes, or whether all of the drawing's strokes consist of empty paths.
+    @inlinable public var isEmpty: Bool {
+        strokes.allSatisfy(\.path.isEmpty)
+    }
+}
+
+#endif

--- a/Sources/SpeziViews/Views/Drawing/PencilKit+Utils.swift
+++ b/Sources/SpeziViews/Views/Drawing/PencilKit+Utils.swift
@@ -11,7 +11,7 @@ import PencilKit
 
 extension PKDrawing: @retroactive Hashable {
     public func hash(into hasher: inout Hasher) {
-        if #available(iOS 18, *) {
+        if #available(iOS 18, macOS 15, visionOS 2, *) {
             hasher.combine(self.bounds)
         } else {
             let bounds = self.bounds


### PR DESCRIPTION
# CanvasView performance improvements

## :recycle: Current situation & Problem
motivation: SpeziQuestionnaire currently has some issues where it ends up in a drawing update loop, bc the delegate's `-canvasViewDrawingDidChange` method gets called initially even if there was no user interaction with the canvas yet, and this then in turn triggers an update of the resopnse object, which in turn can (under some circumstances) trigger a reload of the canvas view, which then again triggers the delegate, etc etc etc.


## :gear: Release Notes
- CanvasView now tries to update the `drawing` Binding only when the value actually changed

## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Better drawing canvas responsiveness via smarter change detection to avoid unnecessary updates
  * Streamlined tool selection handling for snappier interactions

* **New Features**
  * Added drawing utilities to improve detection of empty drawings and enable stable drawing comparisons
<!-- end of auto-generated comment: release notes by coderabbit.ai -->