### PR TITLE
add WIP FilePicker control

### DIFF
--- a/Sources/SpeziViews/Resources/Localizable.xcstrings
+++ b/Sources/SpeziViews/Resources/Localizable.xcstrings
@@ -12,6 +12,7 @@
       }
     },
     "A" : {
+      "extractionState" : "stale",
       "localizations" : {
         "sv" : {
           "stringUnit" : {
@@ -22,6 +23,7 @@
       }
     },
     "B" : {
+      "extractionState" : "stale",
       "localizations" : {
         "sv" : {
           "stringUnit" : {
@@ -165,6 +167,7 @@
       }
     },
     "Option %u" : {
+      "extractionState" : "stale",
       "localizations" : {
         "sv" : {
           "stringUnit" : {
@@ -193,9 +196,6 @@
 
     },
     "Select Videos" : {
-
-    },
-    "Take Photo" : {
 
     }
   },

--- a/Sources/SpeziViews/Resources/Localizable.xcstrings
+++ b/Sources/SpeziViews/Resources/Localizable.xcstrings
@@ -151,6 +151,9 @@
         }
       }
     },
+    "Not Yet Implemented" : {
+
+    },
     "nothing selected" : {
       "localizations" : {
         "sv" : {
@@ -170,6 +173,30 @@
           }
         }
       }
+    },
+    "Select File" : {
+
+    },
+    "Select Files" : {
+
+    },
+    "Select Image" : {
+
+    },
+    "Select Images" : {
+
+    },
+    "Select Photo" : {
+
+    },
+    "Select Video" : {
+
+    },
+    "Select Videos" : {
+
+    },
+    "Take Photo" : {
+
     }
   },
   "version" : "1.0"

--- a/Sources/SpeziViews/Views/Controls/FilePicker.swift
+++ b/Sources/SpeziViews/Views/Controls/FilePicker.swift
@@ -1,0 +1,201 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+// swiftlint:disable file_types_order
+
+import PhotosUI
+import SpeziFoundation
+import SpeziViews
+import SwiftUI
+import UniformTypeIdentifiers
+
+
+/// Reusable view that offers file import options from a range of sources.
+public struct _FilePicker<Label: View>: View { // swiftlint:disable:this type_name
+    public enum Item: Sendable {
+        case file(URL)
+        case photo(PhotosPickerItem)
+    }
+    
+    @Environment(\.isEnabled) private var isEnabled
+    private let label: @MainActor (_ suggestedTitle: LocalizedStringResource) -> Label
+    private let enabledTypes: Set<UTType>
+    private let allowMultipleSelection: Bool
+    private let selectionHandler: @Sendable ([Item]) -> Void
+    @State private var isShowingPhotosPicker = false
+    @State private var isShowingFileImporter = false
+    @State private var isShowingCameraSheet = false
+    @State private var viewState: ViewState = .idle
+    @State private var selectedPhotos: [PhotosPickerItem] = []
+    
+    public var body: some View {
+        // IDEAS
+        // - if there is only one enabled uti, we should skip the menu!
+        // - if there are no enabled UTIs, we show the regular menu, but disable it!
+        Menu {
+            importMenuContents
+        } label: {
+            label(suggestedTitle)
+        }
+        .accessibilityIdentifier("FilePickerButton")
+        .listRowInsets(EdgeInsets())
+        .viewStateAlert(state: $viewState)
+        // We need all of these modifiers placed here at the top level, since the buttons that trigger them are in the Menu,
+        // and will disappear when tapped (bc the menu gets closed)
+        .photosPicker(
+            isPresented: $isShowingPhotosPicker,
+            selection: $selectedPhotos,
+            // Issue (here and below) what if the user already has selected an image, and is now also opening the file picker?
+            // in a single-selection scenario, we'd either need to remove the image, or disable the file picker.
+            maxSelectionCount: allowMultipleSelection ? nil : 1,
+            selectionBehavior: .default,
+            matching: .any(of: Array {
+                if shouldEnable(.movie) {
+                    .videos
+                }
+                if shouldEnable(.image) {
+                    // QUESTION if the user has live photos enabled, would this filter only photos w/out a live photo attached,
+                    // or would it still include everything?
+                    .images
+                }
+            }),
+            preferredItemEncoding: .automatic
+        )
+        .fileImporter(
+            isPresented: $isShowingFileImporter,
+            allowedContentTypes: Array(enabledTypes),
+            allowsMultipleSelection: allowMultipleSelection
+        ) { result in
+            switch result {
+            case .success(let urls):
+                selectionHandler(urls.map { .file($0) })
+            case .failure(let error):
+                viewState = .error(AnyLocalizedError(error: error))
+            }
+        }
+        .sheet(isPresented: $isShowingCameraSheet) {
+            Text("Not Yet Implemented", bundle: .module)
+        }
+        .onChange(of: selectedPhotos) { _, newValue in
+            guard !newValue.isEmpty else {
+                return
+            }
+            // it seems that the PhotosPicker only updates the binding, once, at the end, when the user confirmed the selection.
+            // if multiple selection is enabled, the binding does not get continuously updated as the selection changes.
+            let photos = exchange(&selectedPhotos, with: [])
+            selectionHandler(photos.map { .photo($0) })
+        }
+    }
+    
+    private var suggestedTitle: LocalizedStringResource {
+        if enabledTypes.allSatisfy({ $0.isCompatible(with: .image) }) {
+            if allowMultipleSelection {
+                LocalizedStringResource("Select Images", bundle: .module)
+            } else {
+                LocalizedStringResource("Select Image", bundle: .module)
+            }
+        } else if enabledTypes.allSatisfy({ $0.isCompatible(with: .movie) }) {
+            if allowMultipleSelection {
+                LocalizedStringResource("Select Videos", bundle: .module)
+            } else {
+                LocalizedStringResource("Select Video", bundle: .module)
+            }
+        } else {
+            if allowMultipleSelection {
+                LocalizedStringResource("Select Files", bundle: .module)
+            } else {
+                LocalizedStringResource("Select File", bundle: .module)
+            }
+        }
+    }
+    
+    @ViewBuilder private var importMenuContents: some View {
+        if shouldEnable(.image) || shouldEnable(.movie) {
+            takePhotoButton
+            selectPhotosButton
+            Divider()
+        }
+        importFileButton
+    }
+    
+    private var takePhotoButton: some View {
+        Button {
+            isShowingCameraSheet = true
+        } label: {
+            SwiftUI.Label(LocalizedStringResource("Take Photo", bundle: .module), systemImage: "camera")
+        }
+    }
+    
+    private var selectPhotosButton: some View {
+        Button {
+            isShowingPhotosPicker = true
+        } label: {
+            SwiftUI.Label(LocalizedStringResource("Select Photo", bundle: .module), systemImage: "photo.on.rectangle")
+        }
+    }
+    
+    private var importFileButton: some View {
+        Button {
+            isShowingFileImporter = true
+        } label: {
+            SwiftUI.Label(LocalizedStringResource("Select File", bundle: .module), systemImage: "document")
+        }
+    }
+    
+    public init(
+        _ contentTypes: Set<UTType>,
+        allowMultipleSelection: Bool,
+        selectionHandler: @escaping @Sendable ([Item]) -> Void,
+        @ViewBuilder label: @escaping @MainActor (_ suggestedTitle: LocalizedStringResource) -> Label
+    ) {
+        self.enabledTypes = contentTypes.isEmpty ? [.data] : contentTypes
+        self.allowMultipleSelection = allowMultipleSelection
+        self.selectionHandler = selectionHandler
+        self.label = label
+    }
+    
+    private func shouldEnable(_ uti: UTType) -> Bool {
+        enabledTypes.contains { $0.isCompatible(with: uti) }
+    }
+}
+
+
+public struct _ListRowFilePickerLabel: View { // swiftlint:disable:this type_name
+    private let title: Text
+    
+    public var body: some View {
+        HStack {
+            Image(systemName: "plus.circle.fill")
+                .foregroundStyle(.green)
+                .accessibilityHidden(true)
+            title
+            Spacer()
+            Image(systemName: "chevron.up.chevron.down")
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+        }
+        .contentShape(Rectangle())
+        .frame(maxHeight: .infinity)
+        .padding()
+    }
+    
+    public init(_ title: LocalizedStringResource) {
+        self.title = Text(title)
+    }
+    
+    public init(_ title: some StringProtocol) {
+        self.title = Text(title)
+    }
+}
+
+
+extension UTType {
+    func isCompatible(with other: Self) -> Bool {
+        self.conforms(to: other) || other.conforms(to: self)
+    }
+}

--- a/Sources/SpeziViews/Views/Controls/FilePicker.swift
+++ b/Sources/SpeziViews/Views/Controls/FilePicker.swift
@@ -10,23 +10,25 @@
 
 import PhotosUI
 import SpeziFoundation
-import SpeziViews
 import SwiftUI
 import UniformTypeIdentifiers
 
 
+/// An item that was selected using the ``_FilePicker``
+public enum _FilePickerItem: Sendable, Hashable { // swiftlint:disable:this type_name
+    case file(URL)
+    case photo(PhotosPickerItem)
+}
+
+
 /// Reusable view that offers file import options from a range of sources.
+@available(watchOS, unavailable)
 public struct _FilePicker<Label: View>: View { // swiftlint:disable:this type_name
-    public enum Item: Sendable {
-        case file(URL)
-        case photo(PhotosPickerItem)
-    }
-    
     @Environment(\.isEnabled) private var isEnabled
     private let label: @MainActor (_ suggestedTitle: LocalizedStringResource) -> Label
     private let enabledTypes: Set<UTType>
     private let allowMultipleSelection: Bool
-    private let selectionHandler: @Sendable ([Item]) -> Void
+    private let selectionHandler: @Sendable ([_FilePickerItem]) -> Void
     @State private var isShowingPhotosPicker = false
     @State private var isShowingFileImporter = false
     @State private var isShowingCameraSheet = false
@@ -54,16 +56,20 @@ public struct _FilePicker<Label: View>: View { // swiftlint:disable:this type_na
             // in a single-selection scenario, we'd either need to remove the image, or disable the file picker.
             maxSelectionCount: allowMultipleSelection ? nil : 1,
             selectionBehavior: .default,
-            matching: .any(of: Array {
-                if shouldEnable(.movie) {
-                    .videos
+            matching: { () -> PHPickerFilter in
+                let enabledTypes: [PHPickerFilter] = Array {
+                    if shouldEnable(.movie) {
+                        .videos
+                    }
+                    if shouldEnable(.image) {
+                        // QUESTION if the user has live photos enabled, would this filter only photos w/out a live photo attached,
+                        // or would it still include everything?
+                        .images
+                    }
                 }
-                if shouldEnable(.image) {
-                    // QUESTION if the user has live photos enabled, would this filter only photos w/out a live photo attached,
-                    // or would it still include everything?
-                    .images
-                }
-            }),
+                // can't have an empty ANY filter
+                return enabledTypes.isEmpty ? .images : .any(of: enabledTypes)
+            }(),
             preferredItemEncoding: .automatic
         )
         .fileImporter(
@@ -93,13 +99,13 @@ public struct _FilePicker<Label: View>: View { // swiftlint:disable:this type_na
     }
     
     private var suggestedTitle: LocalizedStringResource {
-        if enabledTypes.allSatisfy({ $0.isCompatible(with: .image) }) {
+        if enabledTypes.allSatisfy({ $0.conforms(to: .image) }) {
             if allowMultipleSelection {
                 LocalizedStringResource("Select Images", bundle: .module)
             } else {
                 LocalizedStringResource("Select Image", bundle: .module)
             }
-        } else if enabledTypes.allSatisfy({ $0.isCompatible(with: .movie) }) {
+        } else if enabledTypes.allSatisfy({ $0.conforms(to: .movie) }) {
             if allowMultipleSelection {
                 LocalizedStringResource("Select Videos", bundle: .module)
             } else {
@@ -116,19 +122,10 @@ public struct _FilePicker<Label: View>: View { // swiftlint:disable:this type_na
     
     @ViewBuilder private var importMenuContents: some View {
         if shouldEnable(.image) || shouldEnable(.movie) {
-            takePhotoButton
             selectPhotosButton
             Divider()
         }
         importFileButton
-    }
-    
-    private var takePhotoButton: some View {
-        Button {
-            isShowingCameraSheet = true
-        } label: {
-            SwiftUI.Label(LocalizedStringResource("Take Photo", bundle: .module), systemImage: "camera")
-        }
     }
     
     private var selectPhotosButton: some View {
@@ -150,7 +147,7 @@ public struct _FilePicker<Label: View>: View { // swiftlint:disable:this type_na
     public init(
         _ contentTypes: Set<UTType>,
         allowMultipleSelection: Bool,
-        selectionHandler: @escaping @Sendable ([Item]) -> Void,
+        selectionHandler: @escaping @Sendable ([_FilePickerItem]) -> Void,
         @ViewBuilder label: @escaping @MainActor (_ suggestedTitle: LocalizedStringResource) -> Label
     ) {
         self.enabledTypes = contentTypes.isEmpty ? [.data] : contentTypes
@@ -195,7 +192,10 @@ public struct _ListRowFilePickerLabel: View { // swiftlint:disable:this type_nam
 
 
 extension UTType {
-    func isCompatible(with other: Self) -> Bool {
+    // we have the bidirectional check here, because:
+    // - if the FilePicker is allowed to select `UTType.image`s we obviously want to allow it to ONLY pick images; but
+    // - if its set to `UTType.data` or `.image`, we want to allow it to pick
+    fileprivate func isCompatible(with other: Self) -> Bool {
         self.conforms(to: other) || other.conforms(to: self)
     }
 }

--- a/Sources/SpeziViews/Views/ManagedNavigationStack/ManagedNavigationStack+Path.swift
+++ b/Sources/SpeziViews/Views/ManagedNavigationStack/ManagedNavigationStack+Path.swift
@@ -32,6 +32,10 @@ extension ManagedNavigationStack {
     /// - ``append(_:)``
     /// - ``append(customView:)``
     /// - ``removeLast()``
+    ///
+    /// ### Inspecting a `Path`
+    /// - ``isEmpty``
+    /// - ``count``
     @MainActor
     @Observable
     public final class Path {
@@ -337,5 +341,20 @@ extension ManagedNavigationStack.Path {
     /// This method allows to manually move backwards within the navigation flow.
     public func removeLast() {
         path.removeLast()
+    }
+}
+
+
+// MARK: Inspecting
+
+extension ManagedNavigationStack.Path {
+    /// Whether the path currently is empty.
+    public var isEmpty: Bool {
+        count == 0
+    }
+    
+    /// The current number of elements in the path.
+    public var count: Int {
+        path.count
     }
 }

--- a/Sources/SpeziViews/Views/Other/FileThumbnail.swift
+++ b/Sources/SpeziViews/Views/Other/FileThumbnail.swift
@@ -1,0 +1,60 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+#if canImport(QuickLookThumbnailing)
+
+import Foundation
+import QuickLookThumbnailing
+import SwiftUI
+
+
+/// An `Image` displaying a thumbnail for a file at a `URL`.
+///
+/// - Note: Not available on watchOS.
+public struct FileThumbnail: View {
+    @Environment(\.displayScale) private var scale
+    private let url: URL
+    private let size: CGSize
+    private let representationTypes: QLThumbnailGenerator.Request.RepresentationTypes
+    @State private var image: UIImage?
+    
+    public var body: some View {
+        VStack {
+            if let image {
+                Image(uiImage: image)
+                    .accessibilityHidden(true)
+            }
+        }
+        .task(id: url) {
+            let request = QLThumbnailGenerator.Request(
+                fileAt: url,
+                size: size,
+                scale: scale,
+                representationTypes: representationTypes
+            )
+            let generator = QLThumbnailGenerator.shared
+            guard let thumbnail = try? await generator.generateBestRepresentation(for: request) else {
+                return
+            }
+            self.image = thumbnail.uiImage
+        }
+    }
+    
+    /// Creates a file thumbnail view for a URL.
+    public init(
+        _ url: URL,
+        size: CGSize = CGSize(width: 50, height: 50),
+        representationTypes: QLThumbnailGenerator.Request.RepresentationTypes = .all
+    ) {
+        self.url = url
+        self.size = size
+        self.representationTypes = representationTypes
+    }
+}
+
+#endif

--- a/Tests/UITests/TestApp/Localizable.xcstrings
+++ b/Tests/UITests/TestApp/Localizable.xcstrings
@@ -22,6 +22,12 @@
     "Alignment" : {
 
     },
+    "Allow Multiple Selection" : {
+
+    },
+    "Allowed Content Types" : {
+
+    },
     "Append Custom View" : {
 
     },
@@ -247,6 +253,9 @@
 
     },
     "Second" : {
+
+    },
+    "Selected Image" : {
 
     },
     "Selection" : {

--- a/Tests/UITests/TestApp/ViewsTests/FilePickerTestView.swift
+++ b/Tests/UITests/TestApp/ViewsTests/FilePickerTestView.swift
@@ -1,0 +1,158 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import PhotosUI
+import SpeziViews
+import SwiftUI
+import UniformTypeIdentifiers
+
+
+struct FilePickerTestView: View {
+    @State private var allowedContentTypes: Set<UTType> = []
+    @State private var allowMultipleSelection = true
+    @State private var items: [_FilePickerItem] = []
+    
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Allow Multiple Selection", isOn: $allowMultipleSelection)
+                allowedContentTypesPicker
+            }
+            Section {
+                ForEach(items, id: \.self) { item in
+                    row(for: item)
+                }
+                _FilePicker(allowedContentTypes, allowMultipleSelection: allowMultipleSelection) { items in
+                    Task { @MainActor in
+                        for item in items {
+                            if !self.items.contains(item) {
+                                self.items.append(item)
+                            }
+                        }
+                    }
+                } label: { suggestedTitle in
+                    _ListRowFilePickerLabel(suggestedTitle)
+                }
+
+            }
+        }
+    }
+    
+    private var allowedContentTypesPicker: some View {
+        NavigationLink {
+            Form {
+                let types: [UTType] = [
+                    .data, .item, .image, .pdf, .tiff, .movie, .video
+                ]
+                ForEach(types, id: \.self) { type in
+                    Button {
+                        if allowedContentTypes.contains(type) {
+                            allowedContentTypes.remove(type)
+                        } else {
+                            allowedContentTypes.insert(type)
+                        }
+                    } label: {
+                        HStack {
+                            Text(type.displayTitle)
+                            Spacer()
+                            if allowedContentTypes.contains(type) {
+                                Image(systemName: "checkmark")
+                                    .accessibilityHidden(true)
+                            }
+                        }
+                    }
+                }
+            }
+        } label: {
+            LabeledContent(
+                "Allowed Content Types",
+                value: allowedContentTypes.map(\.displayTitle).sorted().joined(separator: ", ")
+            )
+        }
+    }
+    
+    @ViewBuilder
+    private func row(for item: _FilePickerItem) -> some View {
+        switch item {
+        case .file(let url):
+            HStack {
+                FileThumbnail(url)
+                VStack(alignment: .leading) {
+                    let fileInfo = url.fileInfo()
+                    Text(url.lastPathComponent)
+                    Text({ () -> String in
+                        var elements: [String] = []
+                        if let uti = fileInfo.uti {
+                            // TODO how can we get smth like "TIFF Image" (ie what the system share sheet does)
+                            elements.append(uti.description)
+                        }
+                        if let size = fileInfo.size {
+                            elements.append(Int64(size).formatted(.byteCount(style: .file, spellsOutZero: true)))
+                        }
+                        return elements.joined(separator: " • ")
+                    }())
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+        case .photo(let item):
+            HStack {
+                PhotosPickerItemThumbnail(item: item)
+                    .frame(height: 50)
+                Text("Selected Image")
+                Spacer()
+            }
+        }
+    }
+}
+
+
+extension FilePickerTestView {
+    private struct PhotosPickerItemThumbnail: View {
+        let item: PhotosPickerItem
+        @State private var image: Image?
+        
+        var body: some View {
+            VStack {
+                if let image {
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                }
+            }
+            .task(id: item) {
+                image = try? await item.loadTransferable(type: Image.self)
+            }
+        }
+    }
+}
+
+
+extension UTType {
+    fileprivate var displayTitle: String {
+        localizedDescription ?? identifier
+    }
+}
+
+
+extension URL {
+    fileprivate struct FileInfo {
+        let size: Int?
+        let uti: UTType?
+    }
+    
+    fileprivate func fileInfo() -> FileInfo {
+        let resourceValues = (try? self.resourceValues(forKeys: [.fileSizeKey])) ?? URLResourceValues()
+        return FileInfo(
+            size: resourceValues.fileSize,
+            uti: UTType(filenameExtension: self.pathExtension)
+        )
+    }
+}

--- a/Tests/UITests/TestApp/ViewsTests/SpeziViewsTests.swift
+++ b/Tests/UITests/TestApp/ViewsTests/SpeziViewsTests.swift
@@ -34,6 +34,7 @@ enum SpeziViewsTests: String, TestAppTests {
     case shareSheet = "Share Sheet"
     #endif
     case dismissButton = "Dismiss Button"
+    case filePicker = "File Picker"
     
     #if !os(macOS)
     @MainActor @ViewBuilder private var label: some View {
@@ -116,6 +117,8 @@ enum SpeziViewsTests: String, TestAppTests {
         #endif
         case .dismissButton:
             DismissButtonTestView()
+        case .filePicker:
+            FilePickerTestView()
         }
     }
 }


### PR DESCRIPTION
# add WIP FilePicker control

## :recycle: Current situation & Problem
we need, in multiple packages, currently, the ability to let the user pick a file/photo. SpeziQuestionnaire already has a `FilePicker` Menu for this purpose; this PR makes that API a bit more generic and moves it into SpeziViews.
the second use case here is SpeziChat/SpeziLLM/(LLMonFHIR?), to allow the user to send images as chat messages.


## :gear: Release Notes
- new: `_FilePicker` API


## :books: Documentation
none yet as this is still unstable


## :white_check_mark: Testing
none yet as this is still unstable


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).